### PR TITLE
Added CSS to fix content alignment on organizations page

### DIFF
--- a/assets/less/thunderbird/organizations.less
+++ b/assets/less/thunderbird/organizations.less
@@ -33,6 +33,10 @@
     }
 }
 
+#main-content {
+  margin: 0 10px;
+}
+
 #download .button {
     padding: 10px;
 }


### PR DESCRIPTION
Created #main-content selector and added a margin of 10px to the left and right margins and a margin of 0px to top and bottom margins.