### PR TITLE
Change Twitter link

### DIFF
--- a/website/_includes/site-footer.html
+++ b/website/_includes/site-footer.html
@@ -27,7 +27,7 @@
           </div>
           <div class="col col-3">
             <ul class="links-social">
-              <li><a class="twitter-button" title="Follow @mozthunderbird on Twitter" href="https://twitter.com/intent/follow?screen_name=mozthunderbird" data-link-type="footer" data-link-name="Twitter (Thunderbird)"><i></i><div>@mozthunderbird</div></a></li>
+              <li><a class="twitter-button" title="Follow @mozthunderbird on Twitter" href="https://twitter.com/mozthunderbird" data-link-type="footer" data-link-name="Twitter (Thunderbird)"><i></i><div>@mozthunderbird</div></a></li>
               <li><a class="facebook" href="https://www.facebook.com/Thunderbird/" data-link-type="footer" data-link-name="Facebook (Thunderbird)"><i></i><div>{{ _('Thunderbird') }}</div></a></li>
             </ul>
             <div class="lang-switcher">


### PR DESCRIPTION
A link to the Thunderbird Twitter page is more convenient to use for users who don't have their own Twitter accounts or don't stay signed in.