### PR TITLE
Align logo and nav with flexbox

### DIFF
--- a/assets/less/sandstone/sandstone-resp.less
+++ b/assets/less/sandstone/sandstone-resp.less
@@ -618,14 +618,23 @@ label.error {
 /* }}} */
 /* {{{ Header Nav */
 #masthead {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    // Fix for IE9 - fall back to stacked elements
+    text-align: center;
 
     h2 {
         padding: (@baseLine * 1.5) 0 @baseLine;
         margin: 0 (@gridGutterWidth / 2);
+        flex: 1;
+
+        img {
+            height: auto;
+        }
     }
 
     nav {
-        float: right;
         margin: 0 16px;
         text-transform: uppercase;
         .font-size(13px);
@@ -1363,6 +1372,11 @@ nav.menu-bar {
     .billboard,
     .container {
         width: @widthTablet - (@gridGutterWidth * 2);
+    }
+
+    #masthead {
+        flex-direction: column;
+        align-items: center;
     }
 
     .main-column {

--- a/website/_includes/base-resp.html
+++ b/website/_includes/base-resp.html
@@ -20,8 +20,7 @@
   <header id="masthead">
 
   {% block site_header_logo %}
-  <h2><a href="{{ url('thunderbird.index') }}">{{ high_res_img('thunderbird/template/logo-wordmark.png', {'alt':
-      'Thunderbird', 'width': '281', 'height': '66'}) }}</a></h2>
+    <h2><a href="{{ url('thunderbird.index') }}">{{ high_res_img('thunderbird/template/logo-wordmark.png', {'alt':'Thunderbird', 'width': '281', 'height': '66'}) }}</a></h2>
   {% endblock %}
 
   {% block site_header_nav %}

--- a/website/_includes/base-resp.html
+++ b/website/_includes/base-resp.html
@@ -19,6 +19,11 @@
 {% block site_header %}
   <header id="masthead">
 
+  {% block site_header_logo %}
+  <h2><a href="{{ url('thunderbird.index') }}">{{ high_res_img('thunderbird/template/logo-wordmark.png', {'alt':
+      'Thunderbird', 'width': '281', 'height': '66'}) }}</a></h2>
+  {% endblock %}
+
   {% block site_header_nav %}
   <nav id="nav-main" role="navigation">
     <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
@@ -97,10 +102,6 @@
       </li>
     </ul>
   </nav>
-  {% endblock %}
-
-  {% block site_header_logo %}
-    <h2><a href="{{ url('thunderbird.index') }}">{{ high_res_img('thunderbird/template/logo-wordmark.png', {'alt': 'Thunderbird', 'width': '281', 'height': '66'}) }}</a></h2>
   {% endblock %}
 
   {% block alt_header %}{% endblock %}


### PR DESCRIPTION
This PR will properly align the menu and the logo in the header area.
Flexbox is supported down to IE v10, for unsupported browsers, the header area falls back to a `block` div with the logo and menu stacked and centered aligned.