### PR TITLE
Add About Page

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -65,6 +65,7 @@ URL_MAPPINGS = {
     'firefox.dnt': 'https://www.mozilla.org/firefox/dnt/',
     'firefox.organizations.faq': 'https://www.mozilla.org/firefox/organizations/faq/',
     'foundation.licensing.website-content': 'https://www.mozilla.org/foundation/licensing/website-content/',
+    'foundation.about': 'https://foundation.mozilla.org/about/',
     'thunderbird.channel': '/channel',
     'thunderbird.enterprise': 'https://wiki.mozilla.org/Thunderbird/tb-enterprise',
     'thunderbird.features': '/features',

--- a/settings.py
+++ b/settings.py
@@ -76,7 +76,7 @@ URL_MAPPINGS = {
     'thunderbird.site.bug-report': 'https://github.com/thundernest/thunderbird-website/issues',
     'contribute': 'https://github.com/thundernest/thunderbird-website',
     'mozorg.home': 'https://www.mozilla.org/',
-    'mozorg.about': 'https://www.mozilla.org/about/',
+    'thunderbird.about': '/about',
     'thunderbird.contact': '/contact',
     'legal.fraud-report': 'https://www.mozilla.org/about/legal/fraud-report/',
     'legal.index': 'https://www.mozilla.org/about/legal/',

--- a/website/_includes/site-footer.html
+++ b/website/_includes/site-footer.html
@@ -12,7 +12,7 @@
           </div>
           <div class="col col-2">
             <ul class="links-join">
-              <li><a href="{{ url('mozorg.about') }}" data-link-type="footer" data-link-name="About">{{ _('About') }}</a></li>
+              <li><a href="{{ url('thunderbird.about') }}" data-link-type="footer" data-link-name="About">{{ _('About') }}</a></li>
               <li class="wrap"><a href="{{ url('thunderbird.contact') }}" data-link-type="footer" data-link-name="Contact Us">{{ _('Contact Us') }}</a></li>
               <li class="wrap"><a href="{{ donate_url('footer') }}" class="donate" data-link-type="footer" data-link-name="Donate">{{ _('Donate') }}</a></li>
               <li class="clear"><a href="{{ url('contribute') }}" data-link-type="footer" data-link-name="Contribute to this site">{{ _('Contribute to this site') }}</a></li>

--- a/website/about/index.html
+++ b/website/about/index.html
@@ -10,7 +10,7 @@
 {{ _('About the Thunderbird Project.') }}
 {% endblock %}
 
-{% block body_id %}contact{% endblock %}
+{% block body_id %}about{% endblock %}
 
 {% block page_css %}
 <link href="/media/css/thunderbird-features.css" rel="stylesheet" type="text/css"/>
@@ -24,7 +24,7 @@
 
 <nav role="directory">
   <ul class="feature-links">
-    <li><a href="#what">{{ _('What is Thunderbird') }}</a></li>
+    <li><a href="#what">{{ _('What is Thunderbird?') }}</a></li>
     <li><a href="#who"</a>{{ _('Who We Are')}}
     <li><a href="#mozilla">{{ _('Thunderbird and Mozilla Foundation') }}</a></li>
   </ul>
@@ -41,8 +41,8 @@
     <div class="row">
       <div class="col full">
         <section>
-            <p>{{ _('Thunderbird is a free and open source email, newsfeed, chat, and calendaring client, that\'s easy to set up and customize. One of the core principles of Thunderbird is the use and promotion of
-            open standards - this focus is a rejection of the world we live in of closed platforms and services that can\'t communicate with each other. We want our users to have freedom and choice in how
+            <p>{{ _('Thunderbird is a free and open source email, newsfeed, chat, and calendaring client, that’s easy to set up and customize. One of the core principles of Thunderbird is the use and promotion of
+            open standards - this focus is a rejection of our world of closed platforms and services that can’t communicate with each other. We want our users to have freedom and choice in how
             they communicate.') }}</p>
         </section>
       </div>
@@ -61,13 +61,13 @@
         <section>
           <h3>{{ _('Our Community') }}</h3>
           <p>{{ _('There is a passionate team of volunteers involved in developing Thunderbird and assisting its users who would welcome your involvement. 
-          Check out our <a href="%(volunteer)s">Get Involved page</a> for how you can participate on the Thunderbird team. We also have paid staff working full-time on Thunderbird, 
-          <a href="https://donate.mozilla.org/thunderbird/">funded by donations</a> from our users. If you\'re curious about who is working on Thunderbird, check out 
-          the <a href="https://wiki.mozilla.org/Thunderbird/Core_Team">list of our core contributors</a>.')|format(volunteer=url('thunderbird.get-involved')) }}</p>
+          Check out our <a href="%(volunteer)s">Get Involved page</a> to learn how you can participate on the Thunderbird team. We also have paid staff working full-time on Thunderbird, 
+          <a href="%(donate)s">funded by donations</a> from our users. If you’re curious about who is working on Thunderbird, check out 
+          the <a href="https://wiki.mozilla.org/Thunderbird/Core_Team">list of our core contributors</a>.')|format(volunteer=url('thunderbird.get-involved'), donate=donate_url('about')) }}</p>
         </section>
         <section>
           <h3>{{ _('Thunderbird Council') }}</h3>
-          <p>{{ _('The Thunderbird project is governed by seven councilors, elected by the Thunderbird community\'s active contributors. You can see the current elected Thunderbird Council members 
+          <p>{{ _('The Thunderbird project is governed by seven councilors, elected by the Thunderbird community’s active contributors. You can see the current elected Thunderbird Council members 
           <a href="https://wiki.mozilla.org/Modules/Thunderbird#Thunderbird_Council">on the Thunderbird wiki</a>.') }}</p>
         </section>
       </div>
@@ -78,16 +78,17 @@
     <h2>{{ _('Thunderbird and Mozilla Foundation') }}</h2>
     <div class="row">
       <div class="col full">
-        <p>{{ _('Thunderbird lives at the nonprofit <a href="https://foundation.mozilla.org/about/">Mozilla Foundation</a>.') }}</p>
+        <p>{{ _('Thunderbird lives at the nonprofit <a href="%(foundation)s">Mozilla Foundation</a>.')|format(foundation=url('foundation.about')) }}</p>
       </div>
     </div>
     <div class="row">
       <div class="col full">
         <section>
-          <p>{{ _('Thunderbird is an independent project with its legal and financial home at <a href="https://foundation.mozilla.org/about/">the Mozilla Foundation</a>. The Mozilla Foundation believes the
+          <p>{{ _('Thunderbird is an independent project with its legal and financial home at <a href="%(foundation)s">the Mozilla Foundation</a>. The Mozilla Foundation believes the
           Internet is a global public resource that must remain open and accessible to all. The Foundation is also the sole shareholder in the Mozilla Corporation, the maker of Firefox - but has its focus
           on advocacy issues and keeping the Internet healthy. The Mozilla Foundation exerts no governance over the project, which instead falls to the Thunderbird Council, elected by the Thunderbird
-          project\'s community. The Mozilla Foundation became Thunderbird\'s home after an exploration of legal homes in 2017.') }}</p>
+          project’s community. The Mozilla Foundation became Thunderbird’s home after an <a href="https://blog.mozilla.org/thunderbird/2017/05/thunderbirds-future-home/">exploration of legal homes
+          in 2017</a.>.')|format(foundation=url('foundation.about')) }}</p>
         </section>
       </div>
     </div>

--- a/website/about/index.html
+++ b/website/about/index.html
@@ -26,7 +26,7 @@
   <ul class="feature-links">
     <li><a href="#what">{{ _('What is Thunderbird') }}</a></li>
     <li><a href="#who"</a>{{ _('Who We Are')}}
-    <li><a href="#mozilla">{{ _('Thunderbird and Mozilla') }}</a></li>
+    <li><a href="#mozilla">{{ _('Thunderbird and Mozilla Foundation') }}</a></li>
   </ul>
 </nav>
 
@@ -60,9 +60,10 @@
       <div class="col full">
         <section>
           <h3>{{ _('Our Community') }}</h3>
-          <p>{{ _('The people making Thunderbird are a dedicated and passionate team of volunteers. We also have paid staff working full-time on Thunderbird, funded by donations from our users. If you want
-          to become a part of the team making Thunderbird, check out our <a href="%(volunteer)s">Get Involved page</a>. You can see a list of our core contributors 
-          <a href="https://wiki.mozilla.org/Thunderbird/Core_Team">on the Thunderbird wiki</a>.')|format(volunteer=url('thunderbird.get-involved')) }}</p>
+          <p>{{ _('There is a passionate team of volunteers involved in developing Thunderbird and assisting its users who would welcome your involvement. 
+          Check out our <a href="%(volunteer)s">Get Involved page</a> for how you can participate on the Thunderbird team. We also have paid staff working full-time on Thunderbird, 
+          <a href="https://donate.mozilla.org/thunderbird/">funded by donations</a> from our users. If you\'re curious about who is working on Thunderbird, check out 
+          the <a href="https://wiki.mozilla.org/Thunderbird/Core_Team">list of our core contributors</a>.')|format(volunteer=url('thunderbird.get-involved')) }}</p>
         </section>
         <section>
           <h3>{{ _('Thunderbird Council') }}</h3>
@@ -74,17 +75,19 @@
   </section><!-- end #who -->
 
   <section id="mozilla">
-    <h2>{{ _('Thunderbird and Mozilla') }}</h2>
+    <h2>{{ _('Thunderbird and Mozilla Foundation') }}</h2>
     <div class="row">
       <div class="col full">
-        <p>{{ _('Thunderbird lives at the nonprofit Mozilla Foundation.') }}</p>
+        <p>{{ _('Thunderbird lives at the nonprofit <a href="https://foundation.mozilla.org/about/">Mozilla Foundation</a>.') }}</p>
       </div>
     </div>
     <div class="row">
       <div class="col full">
         <section>
-          <p>{{ _('Thunderbird is an independent project with its legal and financial home at the Mozilla Foundation. The Mozilla Foundation exerts no governance over the project, which instead falls to
-          the Thunderbird Council, elected by the Thunderbird project\'s community. The Mozilla Foundation became Thunderbird\'s home after an exploration of other potential legal homes in 2017.') }}</p>
+          <p>{{ _('Thunderbird is an independent project with its legal and financial home at <a href="https://foundation.mozilla.org/about/">the Mozilla Foundation</a>. The Mozilla Foundation believes the
+          Internet is a global public resource that must remain open and accessible to all. The Foundation is also the sole shareholder in the Mozilla Corporation, the maker of Firefox - but has its focus
+          on advocacy issues and keeping the Internet healthy. The Mozilla Foundation exerts no governance over the project, which instead falls to the Thunderbird Council, elected by the Thunderbird
+          project\'s community. The Mozilla Foundation became Thunderbird\'s home after an exploration of legal homes in 2017.') }}</p>
         </section>
       </div>
     </div>

--- a/website/about/index.html
+++ b/website/about/index.html
@@ -1,0 +1,94 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "_includes/base-resp.html" %}
+
+{% block page_title %}{{ _('About Us') }}{% endblock %}
+
+{% block page_desc %}
+{{ _('About the Thunderbird Project.') }}
+{% endblock %}
+
+{% block body_id %}contact{% endblock %}
+
+{% block page_css %}
+<link href="/media/css/thunderbird-features.css" rel="stylesheet" type="text/css"/>
+{% endblock %}
+
+{% block content %}
+<header id="main-feature">
+  <h1>{{ self.page_title() }}</h1>
+  <h2>{{ self.page_desc() }}</h2>
+</header>
+
+<nav role="directory">
+  <ul class="feature-links">
+    <li><a href="#what">{{ _('What is Thunderbird') }}</a></li>
+    <li><a href="#who"</a>{{ _('Who We Are')}}
+    <li><a href="#mozilla">{{ _('Thunderbird and Mozilla') }}</a></li>
+  </ul>
+</nav>
+
+<main role="main">
+  <section id="what">
+    <h2>{{ _('What is Thunderbird?') }}</h2>
+    <div class="row">
+      <div class="col full">
+        <p>{{ _('Software made to make email easier.') }}</p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col full">
+        <section>
+            <p>{{ _('Thunderbird is a free and open source email, newsfeed, chat, and calendaring client, that\'s easy to set up and customize. One of the core principles of Thunderbird is the use and promotion of
+            open standards - this focus is a rejection of the world we live in of closed platforms and services that can\'t communicate with each other. We want our users to have freedom and choice in how
+            they communicate.') }}</p>
+        </section>
+      </div>
+    </div>
+  </section><!-- end #what -->
+
+  <section id="who">
+    <h2>{{ _('Who We Are') }}</h2>
+    <div class="row">
+      <div class="col full">
+        <p>{{ _('We are a community making communication free and open.') }}</p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col full">
+        <section>
+          <h3>{{ _('Our Community') }}</h3>
+          <p>{{ _('The people making Thunderbird are a dedicated and passionate team of volunteers. We also have paid staff working full-time on Thunderbird, funded by donations from our users. If you want
+          to become a part of the team making Thunderbird, check out our <a href="%(volunteer)s">Get Involved page</a>. You can see a list of our core contributors 
+          <a href="https://wiki.mozilla.org/Thunderbird/Core_Team">on the Thunderbird wiki</a>.')|format(volunteer=url('thunderbird.get-involved')) }}</p>
+        </section>
+        <section>
+          <h3>{{ _('Thunderbird Council') }}</h3>
+          <p>{{ _('The Thunderbird project is governed by seven councilors, elected by the Thunderbird community\'s active contributors. You can see the current elected Thunderbird Council members 
+          <a href="https://wiki.mozilla.org/Modules/Thunderbird#Thunderbird_Council">on the Thunderbird wiki</a>.') }}</p>
+        </section>
+      </div>
+    </div>
+  </section><!-- end #who -->
+
+  <section id="mozilla">
+    <h2>{{ _('Thunderbird and Mozilla') }}</h2>
+    <div class="row">
+      <div class="col full">
+        <p>{{ _('Thunderbird lives at the nonprofit Mozilla Foundation.') }}</p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col full">
+        <section>
+          <p>{{ _('Thunderbird is an independent project with its legal and financial home at the Mozilla Foundation. The Mozilla Foundation exerts no governance over the project, which instead falls to
+          the Thunderbird Council, elected by the Thunderbird project\'s community. The Mozilla Foundation became Thunderbird\'s home after an exploration of other potential legal homes in 2017.') }}</p>
+        </section>
+      </div>
+    </div>
+  </section><!-- end #mozilla -->
+</main>
+{% endblock %}
+


### PR DESCRIPTION
I intend to add Thunderbird Council members with pictures and titles to the page once the current election is over.

Also, I would like some guidance on a better way to link out to the Thunderbird wiki pages with the list of core contributors and the Council list.