### PR TITLE
Add Blog to nav bar

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -84,6 +84,7 @@ URL_MAPPINGS = {
     'privacy.notices.websites': 'https://www.mozilla.org/privacy/websites/#cookies',
     'privacy.notices.thunderbird': 'https://www.mozilla.org/privacy/thunderbird/',
     'support': 'https://support.mozilla.org/products/thunderbird/',
+    'blog': 'https://blog.mozilla.org/thunderbird'
 
 }
 

--- a/website/_includes/base-resp.html
+++ b/website/_includes/base-resp.html
@@ -84,9 +84,9 @@
         </li>
       {% endif %}
       {% if LANG.startswith('en-') %}
-        <li id="nav-main-contact">
-          <a href="{{ url('thunderbird.contact') }}" tabindex="0">
-            {{_('Contact Us')}}
+        <li id="nav-main-blog">
+          <a href="{{ url('blog') }}" tabindex="0">
+            {{_('Blog')}}
           </a>
         </li>
       {% endif %}


### PR DESCRIPTION
As per #86 - I thought having the blog in the nav bar would be better than contact us, which can be found in the footer and frankly it would seem as though most people we want to contact us would know to look there vs the randos who have hit us up via press@thunderbird.net already asking how to fix their Thunderbird.