### PR TITLE
[Fix #108] Added Add-ons mailing lists to communication links

### DIFF
--- a/website/get-involved/index.html
+++ b/website/get-involved/index.html
@@ -280,6 +280,9 @@
                         <li>{{ _('<a href="https://wiki.mozilla.org/Thunderbird/tb-enterprise">tb-enterprise</a> -
                             For ADMINISTRATORS to discuss large scale deployment and configuration of Thunderbird.') }}
                         </li>
+                        <li>{{ _('<a href="https://thunderbird.topicbox.com/groups/addons">Add-on Developers List</a> -
+                            For general discussions about creating add-ons, and is for add-on developers who need support in creating their add-ons.') }}
+                        </li>
                     </ul>
                 </section>
                 <section>


### PR DESCRIPTION
* Added Add-ons mailing lists to communication links section of the get involved page.