### PR TITLE
Replaced links to MDN [Fix #111]

### DIFF
--- a/website/get-involved/index.html
+++ b/website/get-involved/index.html
@@ -47,7 +47,7 @@
                 <section>
                     <h3>{{ _('What is Open Source Software?') }}</h3>
                     <p>{{ _('Thunderbird is open source software, meaning that anyone can inspect, modify, enhance it, and share it. But the fun is not just for programmers!
-                        Thunderbird is created by a community of designers, translators, documentation writers and support people in addition to developers. We invite anyone to come and 
+                        Thunderbird is created by a community of designers, translators, documentation writers and support people in addition to developers. We invite anyone to come and
                         participate in the creation of Thunderbird. Regardless of your skillset, we’re sure there is something you can add to our community and project.') }}</p>
                 </section>
             </div>
@@ -64,13 +64,9 @@
             <div class="col full">
                 <section>
                     <h3>{{ _('Getting Started') }}</h3>
-                    <p>{{ _('Read the <a
-                            href="https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Introduction">Developer
-                        Guide</a> on MDN. That will give you a general overview of the Mozilla ecosystem. Thunderbird
-                        participates in that ecosystem, so you will need that overview as you join in the work.</p>
-                    <p>Read the <a
-                                href="https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Thunderbird_build">Simple
-                            Thunderbird build</a> guide on MDN to learn how to run your first build successfully. You will learn how to get the code, set any necessary configuration, build the calendar, rebuild after checking out new code, etc. It\'s a good read. Don\'t just skim it.') }}</p>
+                    <p>{{ _('If you would like to learn how to contribute code to Thunderbird, check out our <a
+                            href="https://developer.thunderbird.net/">developer
+                        documentation.</a> You will learn how to get the code, set any necessary configuration, build the calendar, rebuild after checking out new code, etc. It is a good read. Don’t just skim it.') }}</p>
                 </section>
                 <section>
                     <h3>{{ _('Code') }}</h3>
@@ -110,10 +106,10 @@
                     </ul>
                 </section>
                 <section>
-                    <h3>{{ _('Extension/Add-On Development') }}</h3>
-                    <p>{{ _('See the <a
-                            href="https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Thunderbird_extensions">documentation
-                        on MDN.</a>') }}</p>
+                    <h3>{{ _('Add-Ons') }}</h3>
+                    <p>{{ _('Learn how to create add-ons and themes by checking out our <a
+                            href="https://developer.thunderbird.net/add-ons/about-add-ons"> developer
+                        documentation. </a>') }}</p>
                 </section>
             </div>
         </div>
@@ -160,8 +156,8 @@
                         <li>{{ _('<a href="https://wiki.mozilla.org/Thunderbird:Home">The Thunderbird section</a> of the
                             Mozilla wiki.') }}
                         </li>
-                        <li>{{ _('<a href="https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird">The Thunderbird
-                            section</a> of MDN.') }}
+                        <li>{{ _('The official <a href="https://developer.thunderbird.net/">Thunderbird developer
+                            website.</a>') }}
                         </li>
                     </ul>
                 </section>
@@ -172,8 +168,8 @@
                             - What you need to know to contribute to the wiki. That page is applicable to the
                             Thunderbird section.') }}
                         </li>
-                        <li>{{ _('<a href="https://developer.mozilla.org/en-US/docs/MDN/Getting_started">Getting started
-                            on MDN</a> - What you need to know to contribute to the Thunderbird section of MDN.') }}
+                        <li>{{ _('You can contribute to the Thunderbird developer documentation via its repository <a href="https://github.com/thundernest/developer-docs"> on
+                            GitHub.</a>') }}
                         </li>
                         <li>{{ _('Support users asking for help on the <a href="https://support.mozilla.org/en-US/questions/thunderbird">Thunderbird Support Forum</a>') }}</li>
                     </ul>


### PR DESCRIPTION
I replaced the link in the "Getting Started" section and changed the wording. I changed the heading of the "Extension/Add-On Development" section to just say "Add-Ons." I changed the link in that section to the thunderbird.net add-ons page and changed the wording. Under Documentation I changed the two spots that referenced MDN. I replaced their links for the correct ones and changed the wording.