### PR TITLE
Remove target attribute from translatable strings

### DIFF
--- a/website/404.html
+++ b/website/404.html
@@ -6,7 +6,7 @@
 
 {% block page_title_prefix %}{{_('Thunderbird')}} — {% endblock %}
 {% block page_title %}{{ _('There’s nothing here!') }}{% endblock %}
-{% block page_desc %}{{ _('The page you are looking for doesn’t exist.<br/>If you think this is a bug, you can <a href="%(bug_report_url)s" target="_blank">report an issue here</a>.')|format(bug_report_url=url('thunderbird.site.bug-report')) }}{% endblock %}
+{% block page_desc %}{{ _('The page you are looking for doesn’t exist.<br/>If you think this is a bug, you can <a href="%(bug_report_url)s">report an issue here</a>.')|format(bug_report_url=url('thunderbird.site.bug-report')) }}{% endblock %}
 
 {% block header_content %}
   <section class="text-center text-white flex flex-col items-center xl:w-full max-w-6xl mx-auto pl-8 pr-8">

--- a/website/_includes/release-notes.html
+++ b/website/_includes/release-notes.html
@@ -38,7 +38,7 @@
   <section  class="pt-20 flex justify-center items-center pl-8 pr-8">
     <aside class="flex flex-col w-full max-w-6xl lg:ml-16 lg:mr-16">
       <p class="font-lg tracking-wider leading-loose mb-6 p-links-blue">
-        {{ _('Check out "What’s New" and "Known Issues" for this version of Thunderbird below. As always, you’re encouraged to <a href="%(feedback)s" target="_blank">tell us what you think</a>, or <a href="%(bugzilla)s" target="_blank">file a bug in Bugzilla</a>')|format(feedback='https://support.mozilla.org/questions/new/thunderbird', bugzilla='https://bugzilla.mozilla.org/') }}
+        {{ _('Check out "What’s New" and "Known Issues" for this version of Thunderbird below. As always, you’re encouraged to <a href="%(feedback)s">tell us what you think</a>, or <a href="%(bugzilla)s">file a bug in Bugzilla</a>')|format(feedback='https://support.mozilla.org/questions/new/thunderbird', bugzilla='https://bugzilla.mozilla.org/') }}
       </p>
       <aside class="font-lg tracking-wider leading-loose mb-6 markup-page">
         {{ release.text|markdown|safe }}

--- a/website/about/index.html
+++ b/website/about/index.html
@@ -60,14 +60,14 @@
       <article class="flex flex-col w-full mb-6">
         <h4 class="subheader-section">{{ _('Our Community') }}</h4>
         <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-          {{ _('There is a passionate team of volunteers involved in developing Thunderbird and assisting its users who would welcome your involvement. Check out our <a href="%(volunteer)s">Get Involved page</a> to learn how you can participate on the Thunderbird team. We also have paid staff working full-time on Thunderbird, <a href="%(donate)s" target="_blank">funded by donations</a> from our users. If you’re curious about who is working on Thunderbird, check out the <a href="%(core_team)s" target="_blank">list of our core contributors</a>.')|format(volunteer=url('thunderbird.get-involved'), donate=donate_url('about'), core_team=url('wiki.moz', '/Thunderbird/Core_Team')) }}
+          {{ _('There is a passionate team of volunteers involved in developing Thunderbird and assisting its users who would welcome your involvement. Check out our <a href="%(volunteer)s">Get Involved page</a> to learn how you can participate on the Thunderbird team. We also have paid staff working full-time on Thunderbird, <a href="%(donate)s">funded by donations</a> from our users. If you’re curious about who is working on Thunderbird, check out the <a href="%(core_team)s">list of our core contributors</a>.')|format(volunteer=url('thunderbird.get-involved'), donate=donate_url('about'), core_team=url('wiki.moz', '/Thunderbird/Core_Team')) }}
         </p>
       </article>
 
       <article class="flex flex-col w-full">
         <h4 class="subheader-section">{{ _('Thunderbird Council') }}</h4>
         <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-          {{ _('The Thunderbird project is governed by seven councilors, elected by the Thunderbird community’s active contributors. You can see the current elected Thunderbird Council members <a href="%(council)s" target="_blank">on the Thunderbird wiki</a>.')|format(council=url('wiki.moz', '/Modules/Thunderbird#Thunderbird_Council')) }}
+          {{ _('The Thunderbird project is governed by seven councilors, elected by the Thunderbird community’s active contributors. You can see the current elected Thunderbird Council members <a href="%(council)s">on the Thunderbird wiki</a>.')|format(council=url('wiki.moz', '/Modules/Thunderbird#Thunderbird_Council')) }}
         </p>
       </article>
     </aside>
@@ -81,12 +81,12 @@
           <aside class="flex flex-col">
             {{ _('Thunderbird and Mozilla Foundation')}}
             <small class="font-normal font-md tracking-normal normal-case p-links-blue">
-              {{ _('Thunderbird lives at the nonprofit <a href="%(foundation)s" target="_blank">Mozilla Foundation</a>.')|format(foundation=url('foundation.about')) }}
+              {{ _('Thunderbird lives at the nonprofit <a href="%(foundation)s">Mozilla Foundation</a>.')|format(foundation=url('foundation.about')) }}
             </small>
           </aside>
         </h3>
         <p class="font-lg tracking-wider leading-loose mb-6 p-links-blue">
-          {{ _('Thunderbird is an independent project with its legal and financial home at <a href="%(foundation)s" target="_blank">the Mozilla Foundation</a>. The Mozilla Foundation believes the Internet is a global public resource that must remain open and accessible to all. It is focused on advocacy issues and keeping the Internet healthy, but is also the sole shareholder in the maker of Firefox, the Mozilla Corporation. Mozilla exerts no governance over the project, which instead falls to the Thunderbird Council, elected by the Thunderbird project’s community. The Mozilla Foundation became Thunderbird’s home after an <a href="%(home_blog_post)s" target="_blank">exploration of legal homes in 2017</a>.')|format(foundation=url('foundation.about'), home_blog_post='https://blog.mozilla.org/thunderbird/2017/05/thunderbirds-future-home/') }}
+          {{ _('Thunderbird is an independent project with its legal and financial home at <a href="%(foundation)s">the Mozilla Foundation</a>. The Mozilla Foundation believes the Internet is a global public resource that must remain open and accessible to all. It is focused on advocacy issues and keeping the Internet healthy, but is also the sole shareholder in the maker of Firefox, the Mozilla Corporation. Mozilla exerts no governance over the project, which instead falls to the Thunderbird Council, elected by the Thunderbird project’s community. The Mozilla Foundation became Thunderbird’s home after an <a href="%(home_blog_post)s">exploration of legal homes in 2017</a>.')|format(foundation=url('foundation.about'), home_blog_post='https://blog.mozilla.org/thunderbird/2017/05/thunderbirds-future-home/') }}
         </p>
       </aside>
     </section>

--- a/website/calendar/holidays/index.html
+++ b/website/calendar/holidays/index.html
@@ -26,10 +26,10 @@
         </aside>
       </h3>
       <p class="font-lg tracking-wider leading-loose mb-6 p-links-blue">
-        {{ _('We&rsquo;ve got some holiday calendar files available for download. You can either download and then import them into Sunbird or Lightning or you can just subscribe to these calendars by copying their URL and then adding them as new remote calendar files. More information on installing a holiday calendar can be found in the <a href="%s"target="_blank">Adding a holiday calendar article</a>.')|format('https://support.mozilla.org/kb/adding-a-holiday-calendar') }}
+        {{ _('We&rsquo;ve got some holiday calendar files available for download. You can either download and then import them into Sunbird or Lightning or you can just subscribe to these calendars by copying their URL and then adding them as new remote calendar files. More information on installing a holiday calendar can be found in the <a href="%s">Adding a holiday calendar article</a>.')|format('https://support.mozilla.org/kb/adding-a-holiday-calendar') }}
       </p>
       <p class="font-lg tracking-wider leading-loose mb-10 mt-0 p-links-blue">
-        {{ _('You can also find calendars to subscribe to at <a href="%s" target="_blank">iCalShare.com</a>.')|format('http://icalshare.com') }}
+        {{ _('You can also find calendars to subscribe to at <a href="%s">iCalShare.com</a>.')|format('http://icalshare.com') }}
       </p>
       <aside class="ml-0 mr-0 self-start text-left text-blue font-semibold">
         <a href="https://addons.thunderbird.net/addon/lightning/" class="btn-join self-start" target="_blank">
@@ -99,7 +99,7 @@
             {{ _('Right-click on this calendar and choose "Export Calendar". Please use the iCalendar (ics) format.') }}
           </li>
           <li class="p-links-blue">
-            {{ _('Open a bug in <a href="%s" target="_blank">Bugzilla</a>.')|format('http://bugzilla.mozilla.org/enter_bug.cgi?product=Calendar&component=Website') }}
+            {{ _('Open a bug in <a href="%s">Bugzilla</a>.')|format('http://bugzilla.mozilla.org/enter_bug.cgi?product=Calendar&component=Website') }}
           </li>
           <li>{{ _('Add your holiday file as an attachment in the new bug.') }}</li>
         </ol>

--- a/website/contact/index.html
+++ b/website/contact/index.html
@@ -26,16 +26,16 @@
     <section class="flex xl:w-full flex-col lg:flex-row max-w-6xl mx-auto justify-between pl-8 pr-8 mb-12 leading-relaxed">
       <article class="flex flex-col p-4 flex-1 lg:max-w-sm mb-10 lg:mb-0 bg-white rounded shadow-lg">
         <h4 class="mt-0 mb-4 uppercase text-blue font-md">
-          {{ _('<a href="%(support)s" class="header-link" target="_blank">Mozilla Support Website</a>')|format(support=url('support')) }}
+          {{ _('<a href="%(support)s" class="header-link">Mozilla Support Website</a>')|format(support=url('support')) }}
         </h4>
         <p class="mt-0 mb-6 flex-1 p-links-blue">
-          {{ _('The best place to start looking for answers if you have questions about Thunderbird is the Mozilla Support website, <a href="%(support)s" target="_blank">specifically the Thunderbird page</a>. There you can search for articles, ask questions, and read tutorials.')|format(support=url('support')) }}
+          {{ _('The best place to start looking for answers if you have questions about Thunderbird is the Mozilla Support website, <a href="%(support)s">specifically the Thunderbird page</a>. There you can search for articles, ask questions, and read tutorials.')|format(support=url('support')) }}
         </p>
       </article>
 
       <article class="flex flex-col p-4 flex-1 lg:max-w-sm mb-10 lg:mb-0 bg-white rounded shadow-lg lg:ml-16 lg:mr-16">
         <h4 class="mt-0 mb-4 uppercase text-blue font-md">
-          {{ _('<a href="https://support.mozilla.org/questions/new/thunderbird" class="header-link" target="_blank">Ask a Question</a>') }}
+          {{ _('<a href="https://support.mozilla.org/questions/new/thunderbird" class="header-link">Ask a Question</a>') }}
         </h4>
         <p class="mt-0 mb-6 flex-1">
           {{ _('You can ask a question on the support website. <b>Remember to be courteous</b>, as most of the people providing support on this site are volunteers and fellow Thunderbird users like you!') }}
@@ -44,10 +44,10 @@
 
       <article class="flex flex-col p-4 flex-1 lg:max-w-sm mb-10 lg:mb-0 bg-white rounded shadow-lg">
         <h4 class="mt-0 mb-4 uppercase text-blue font-md">
-          {{ _('<a href="irc://irc.mozilla.org/thunderbird" class="header-link" target="_blank">Live Chat on IRC</a>') }}
+          {{ _('<a href="irc://irc.mozilla.org/thunderbird" class="header-link">Live Chat on IRC</a>') }}
         </h4>
         <p class="mt-0 mb-6 flex-1 p-links-blue">
-          {{ _('You can chat with other users and members of the Thunderbird team on the <a href="irc://irc.mozilla.org/thunderbird" target="_blank">#thunderbird channel on Mozilla’s IRC</a>. You can set up IRC in Thunderbird by following the <a href="https://support.mozilla.org/kb/instant-messaging-and-chat#w_configuring-chat" target="_blank">instructions on SUMO</a>.') }}
+          {{ _('You can chat with other users and members of the Thunderbird team on the <a href="irc://irc.mozilla.org/thunderbird">#thunderbird channel on Mozilla’s IRC</a>. You can set up IRC in Thunderbird by following the <a href="https://support.mozilla.org/kb/instant-messaging-and-chat#w_configuring-chat">instructions on SUMO</a>.') }}
         </p>
       </article>
     </section>
@@ -59,7 +59,7 @@
         <article class="flex flex-col w-full mb-6 lg:pr-8">
           <h4 class="subheader-section">{{ _('Security') }}</h4>
           <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-            {{ _('To report a security issue related to Thunderbird, please register an account at <a href="https://bugzilla.mozilla.org/" target="_blank">Bugzilla</a>, and describe the issue in a new Thunderbird <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Thunderbird" target="_blank">bug report</a>. If you select the <i>Security checkmark</i> before you submit, then only members of our security team will have access to your report.') }}
+            {{ _('To report a security issue related to Thunderbird, please register an account at <a href="https://bugzilla.mozilla.org/">Bugzilla</a>, and describe the issue in a new Thunderbird <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Thunderbird">bug report</a>. If you select the <i>Security checkmark</i> before you submit, then only members of our security team will have access to your report.') }}
           </p>
           <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
             {{ _('Bugzilla is also our preferred medium for coordinating the disclosure of security incidents and for discussing embargo dates. If you don’t get a timely response in Bugzilla, please contact us at <a href="mailto:security@thunderbird.net">security@thunderbird.net</a> and mention the respective bug numbers. Encrypted email can be arranged on demand.') }}

--- a/website/get-involved/index.html
+++ b/website/get-involved/index.html
@@ -76,7 +76,7 @@
           </aside>
         </h3>
         <p class="font-lg tracking-wider leading-loose mb-6 p-links-blue">
-          {{ _('If you would like to learn how to contribute code to Thunderbird, check out our <a href="https://developer.thunderbird.net/" target="_blank">developer documentation.</a> You will learn how to get the code, set any necessary configuration, build the calendar, rebuild after checking out new code, etc. It is a good read. Don’t just skim it.') }}
+          {{ _('If you would like to learn how to contribute code to Thunderbird, check out our <a href="https://developer.thunderbird.net/">developer documentation.</a> You will learn how to get the code, set any necessary configuration, build the calendar, rebuild after checking out new code, etc. It is a good read. Don’t just skim it.') }}
         </p>
       </aside>
     </section>
@@ -90,13 +90,13 @@
           </p>
           <ul class="font-md tracking-wider leading-loose mb-10 p-links-blue">
             <li>
-              {{ _('<a href="https://hg.mozilla.org/comm-central/" target="_blank">comm-central</a> is the main Thunderbird repository.') }}
+              {{ _('<a href="https://hg.mozilla.org/comm-central/">comm-central</a> is the main Thunderbird repository.') }}
             </li>
             <li>
-              {{ _('Thunderbird also relies on the code from <a href="https://hg.mozilla.org/mozilla-central/" target="_blank">mozilla-central</a>. See the <a href="https://developer.thunderbird.net/the-basics/building-thunderbird" target="_blank">build instructions</a> for how to obtain all the code needed to build.') }}
+              {{ _('Thunderbird also relies on the code from <a href="https://hg.mozilla.org/mozilla-central/">mozilla-central</a>. See the <a href="https://developer.thunderbird.net/the-basics/building-thunderbird">build instructions</a> for how to obtain all the code needed to build.') }}
             </li>
             <li>
-              {{ _('You can search the code on <a href="https://searchfox.org/comm-central/source" target="_blank">SearchFox</a>.') }}
+              {{ _('You can search the code on <a href="https://searchfox.org/comm-central/source">SearchFox</a>.') }}
             </li>
           </ul>
           <p class="font-md tracking-wide leading-loose mt-0 mb-0">
@@ -104,10 +104,10 @@
           </p>
           <ul class="font-md tracking-wider leading-loose mb-6 p-links-blue">
             <li>
-              {{ _('<a href="https://github.com/thundernest" target="_blank">Thundernest</a> contains the code for Thunderbird.net (this site), as well as the Thunderbird web server setup scripts.') }}
+              {{ _('<a href="https://github.com/thundernest">Thundernest</a> contains the code for Thunderbird.net (this site), as well as the Thunderbird web server setup scripts.') }}
             </li>
             <li>
-              {{ _('<a href="https://github.com/mozilla-comm" target="_blank">Thunderbird on GitHub</a> contains several Thunderbird related repositories.') }}
+              {{ _('<a href="https://github.com/mozilla-comm">Thunderbird on GitHub</a> contains several Thunderbird related repositories.') }}
             </li>
           </ul>
         </article>
@@ -117,20 +117,20 @@
         <article class="flex flex-col mb-6 lg:pl-8">
           <h4 class="subheader-section">{{ _('Bugs') }}</h4>
           <p class="font-md tracking-wide leading-loose mb-0 mt-0 p-links-blue">
-            {{ _('All Thunderbird bugs live on <a href="https://bugzilla.mozilla.org" target="_blank">Mozilla’s Bugzilla</a>. Bugzilla is a powerful tool and can be intimidating if you are not used to it. So check out these pre-defined searches to test the waters:') }}
+            {{ _('All Thunderbird bugs live on <a href="https://bugzilla.mozilla.org">Mozilla’s Bugzilla</a>. Bugzilla is a powerful tool and can be intimidating if you are not used to it. So check out these pre-defined searches to test the waters:') }}
           </p>
           <ul class="font-md tracking-wider leading-loose mb-6 p-links-blue">
             <li>
-              {{ _('You can help out by triaging <a href="https://bugzilla.mozilla.org/buglist.cgi?list_id=14114741&chfieldto=Now&query_format=advanced&chfield=%5BBug%20creation%5D&chfieldfrom=-3d&product=MailNews%20Core&product=Thunderbird" target="_blank">incoming bugs</a>. Known bugs should be marked as duplicates, unconfirmed bugs often needs someone to see if they too can reproduce.') }}
+              {{ _('You can help out by triaging <a href="https://bugzilla.mozilla.org/buglist.cgi?list_id=14114741&chfieldto=Now&query_format=advanced&chfield=%5BBug%20creation%5D&chfieldfrom=-3d&product=MailNews%20Core&product=Thunderbird">incoming bugs</a>. Known bugs should be marked as duplicates, unconfirmed bugs often needs someone to see if they too can reproduce.') }}
               </li>
             <li>
-              {{ _('<a href="https://mzl.la/2oijxOd" target="_blank">"Good first bugs"</a> which are extra easy to try and fix when you are just starting out.') }}
+              {{ _('<a href="https://mzl.la/2oijxOd">"Good first bugs"</a> which are extra easy to try and fix when you are just starting out.') }}
             </li>
             <li>
-              {{ _('<a href="http://www.joshmatthews.net/bugsahoy/?thunderbird=1" target="_blank">Mentored Bugs</a> have a mentor who commits to helping you every step of the way.') }}
+              {{ _('<a href="http://www.joshmatthews.net/bugsahoy/?thunderbird=1">Mentored Bugs</a> have a mentor who commits to helping you every step of the way.') }}
             </li>
             <li>
-              {{ _('<a href="https://wiki.mozilla.org/Thunderbird:Bug_Queries" target="_blank">Thunderbird bug queries</a> is a wiki page with lots of useful searches.') }}
+              {{ _('<a href="https://wiki.mozilla.org/Thunderbird:Bug_Queries">Thunderbird bug queries</a> is a wiki page with lots of useful searches.') }}
             </li>
           </ul>
         </article>
@@ -139,7 +139,7 @@
       <aside class="flex flex-col">
         <h4 class="subheader-section">{{ _('Add-Ons') }}</h4>
         <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-          {{ _('Learn how to create add-ons and themes by checking out our <a href="https://developer.thunderbird.net/add-ons/about-add-ons" target="_blank">developer documentation. </a>') }}
+          {{ _('Learn how to create add-ons and themes by checking out our <a href="https://developer.thunderbird.net/add-ons/about-add-ons">developer documentation. </a>') }}
         </p>
       </aside>
     </section>
@@ -158,14 +158,14 @@
           </aside>
         </h3>
         <p class="font-lg tracking-wider leading-loose mb-6 p-links-blue">
-          {{ _('Please share ideas and concepts by posting them on <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Thunderbird&bug_severity=enhancement" target="_blank">Bugzilla</a>.<br/>You can also discuss design in the <a href="irc://irc.mozilla.org/maildev" target="_blank">#maildev</a> irc channel, or the <a href="https://discourse.mozilla.org/c/thunderbird" target="_blank">Discourse category</a>.') }}
+          {{ _('Please share ideas and concepts by posting them on <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Thunderbird&bug_severity=enhancement">Bugzilla</a>.<br/>You can also discuss design in the <a href="irc://irc.mozilla.org/maildev">#maildev</a> irc channel, or the <a href="https://discourse.mozilla.org/c/thunderbird">Discourse category</a>.') }}
         </p>
       </aside>
 
       <aside class="flex flex-col w-full lg:w-1/2 lg:mt-20">
         <h4 class="subheader-section">{{ _('Style Guide') }}</h4>
         <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-          {{ _('Looking for the Thunderbird logo, icons, color palette, or other design resources? Check out our <a href="%(style_guide)s" target="_blank">style guide</a>.')|format(style_guide=url('thunderbird.style')) }}
+          {{ _('Looking for the Thunderbird logo, icons, color palette, or other design resources? Check out our <a href="%(style_guide)s">style guide</a>.')|format(style_guide=url('thunderbird.style')) }}
         </p>
       </aside>
     </section>
@@ -189,10 +189,10 @@
         <h4 class="subheader-section">{{ _('Where documentation lives') }}</h4>
         <ul class="font-md tracking-wider leading-loose mb-10 p-links-blue">
           <li>
-            {{ _('<a href="https://wiki.mozilla.org/Thunderbird:Home" target="_blank">The Thunderbird section</a> of the Mozilla wiki.') }}
+            {{ _('<a href="https://wiki.mozilla.org/Thunderbird:Home">The Thunderbird section</a> of the Mozilla wiki.') }}
           </li>
           <li>
-            {{ _('The official <a href="https://developer.thunderbird.net/" target="_blank">Thunderbird developer website.</a>') }}
+            {{ _('The official <a href="https://developer.thunderbird.net/">Thunderbird developer website.</a>') }}
           </li>
         </ul>
       </article>
@@ -203,13 +203,13 @@
         <h4 class="subheader-section">{{ _('Contributing to documentation') }}</h4>
         <ul class="font-md tracking-wider leading-loose mb-6 p-links-blue">
           <li>
-            {{ _('<a href="https://wiki.mozilla.org/MozillaWiki:Policies/Accounts" target="_blank">MozillaWiki:Policies/Accounts</a> - What you need to know to contribute to the wiki. That page is applicable to the Thunderbird section.') }}
+            {{ _('<a href="https://wiki.mozilla.org/MozillaWiki:Policies/Accounts">MozillaWiki:Policies/Accounts</a> - What you need to know to contribute to the wiki. That page is applicable to the Thunderbird section.') }}
           </li>
           <li>
-            {{ _('You can contribute to the Thunderbird developer documentation via its repository <a href="https://github.com/thundernest/developer-docs" target="_blank"> on GitHub.</a>') }}
+            {{ _('You can contribute to the Thunderbird developer documentation via its repository <a href="https://github.com/thundernest/developer-docs"> on GitHub.</a>') }}
           </li>
           <li>
-            {{ _('Support users asking for help on the <a href="https://support.mozilla.org/en-US/questions/thunderbird" target="_blank">Thunderbird Support Forum</a>') }}
+            {{ _('Support users asking for help on the <a href="https://support.mozilla.org/en-US/questions/thunderbird">Thunderbird Support Forum</a>') }}
           </li>
         </ul>
       </article>
@@ -229,7 +229,7 @@
           </aside>
         </h3>
         <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-          {{ _('See <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Thunderbird/Thunderbird_Localization" target="_blank">Thunderbird Localization</a> on MDN.') }}
+          {{ _('See <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Thunderbird/Thunderbird_Localization">Thunderbird Localization</a> on MDN.') }}
         </p>
       </article>
     </aside>
@@ -246,7 +246,7 @@
           </aside>
         </h3>
         <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-          {{ _('See <a href="https://wiki.mozilla.org/Thunderbird:Testing" target="_blank">Thunderbird:Testing</a> on the Mozilla Wiki.') }}
+          {{ _('See <a href="https://wiki.mozilla.org/Thunderbird:Testing">Thunderbird:Testing</a> on the Mozilla Wiki.') }}
         </p>
       </article>
     </aside>
@@ -270,26 +270,26 @@
         <article class="flex flex-col w-full mb-6 lg:pl-8">
           <h4 class="subheader-section">{{ _('Discussion Forums') }}</h4>
           <ul class="font-md tracking-wider leading-loose mb-6 p-links-blue">
-            <li>{{ _('<a href="https://support.mozilla.org/en-US/questions/thunderbird" target="_blank">Thunderbird Support Forum</a>') }}
+            <li>{{ _('<a href="https://support.mozilla.org/en-US/questions/thunderbird">Thunderbird Support Forum</a>') }}
             </li>
             <li>
-              {{ _('<a href="https://discourse.mozilla.org/" target="_blank">Mozilla’s Discourse</a>') }}
+              {{ _('<a href="https://discourse.mozilla.org/">Mozilla’s Discourse</a>') }}
               <ul>
                 <li>
-                  {{ _('<a href="https://discourse.mozilla.org/c/thunderbird" target="_blank">Thunderbird</a>') }}</li>
+                  {{ _('<a href="https://discourse.mozilla.org/c/thunderbird">Thunderbird</a>') }}</li>
                 <li>
-                  {{ _('<a href="https://discourse.mozilla.org/c/thunderbird/beta" target="_blank">Thunderbird Beta</a>') }}
+                  {{ _('<a href="https://discourse.mozilla.org/c/thunderbird/beta">Thunderbird Beta</a>') }}
                 </li>
                 <li>
-                  {{ _('<a href="https://discourse.mozilla.org/c/thunderbird/addons" target="_blank">Thunderbird Add-Ons</a>') }}
+                  {{ _('<a href="https://discourse.mozilla.org/c/thunderbird/addons">Thunderbird Add-Ons</a>') }}
                 </li>
               </ul>
             </li>
             <li>
-              {{ _('<a href="http://forums.mozillazine.org/viewforum.php?f=29" target="_blank">Thunderbird Builds</a> on MozillaZine - For help with building Thunderbird and using daily builds.') }}
+              {{ _('<a href="http://forums.mozillazine.org/viewforum.php?f=29">Thunderbird Builds</a> on MozillaZine - For help with building Thunderbird and using daily builds.') }}
             </li>
             <li>
-              {{ _('<a href="https://groups.google.com/forum/#!forum/mozilla.support.thunderbird" target="_blank">mozilla.support.thunderbird</a> is a Google Group for support.')}}
+              {{ _('<a href="https://groups.google.com/forum/#!forum/mozilla.support.thunderbird">mozilla.support.thunderbird</a> is a Google Group for support.')}}
             </li>
           </ul>
         </article>
@@ -299,19 +299,19 @@
         <article class="flex flex-col w-full mb-6 lg:pl-8">
           <h4 class="subheader-section">{{ _('IRC Channels on irc.mozilla.org') }}</h4>
           <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-            {{ _('You can use <a href="https://mibbit.com/" target="_blank">Mibbit.com</a> if you don’t already have a preferred IRC client..') }}
+            {{ _('You can use <a href="https://mibbit.com/">Mibbit.com</a> if you don’t already have a preferred IRC client..') }}
           </p>
           <ul class="font-md tracking-wider leading-loose mb-6 p-links-blue">
             <li>
-              {{ _('<a href="irc://irc.mozilla.org/maildev" target="_blank">#maildev</a> - For hacking on Thunderbird.') }}</li>
+              {{ _('<a href="irc://irc.mozilla.org/maildev">#maildev</a> - For hacking on Thunderbird.') }}</li>
             <li>
-              {{ _('<a href="irc://irc.mozilla.org/extdev" target="_blank">#extdev</a> - For building Thunderbird add-ons/extensions.') }}
+              {{ _('<a href="irc://irc.mozilla.org/extdev">#extdev</a> - For building Thunderbird add-ons/extensions.') }}
             </li>
             <li>
-              {{ _('<a href="irc://irc.mozilla.org/thunderbird" target="_blank">#thunderbird</a> - For general questions and support.') }}
+              {{ _('<a href="irc://irc.mozilla.org/thunderbird">#thunderbird</a> - For general questions and support.') }}
             </li>
             <li>
-              {{ _('<a href="irc://irc.mozilla.org/tb-qa" target="_blank">#tb-qa</a> - For QA chat.') }}</li>
+              {{ _('<a href="irc://irc.mozilla.org/tb-qa">#tb-qa</a> - For QA chat.') }}</li>
           </ul>
         </article>
       </aside>
@@ -321,29 +321,29 @@
           <h4 class="subheader-section">{{ _('Mailing Lists') }}</h4>
           <ul class="font-md tracking-wider leading-loose mb-6 p-links-blue">
             <li>
-              {{ _('<a href="https://wiki.mozilla.org/Thunderbird/tb-planning" target="_blank">tb-planning</a> (<a href="https://groups.google.com/forum/#!forum/tb-planning" target="_blank">Google Group Mirror</a>) - For high level topics.') }}
+              {{ _('<a href="https://wiki.mozilla.org/Thunderbird/tb-planning">tb-planning</a> (<a href="https://groups.google.com/forum/#!forum/tb-planning">Google Group Mirror</a>) - For high level topics.') }}
             </li>
             <li>
-              {{ _('<a href="http://lists.thunderbird.net/mailman/listinfo/maildev_lists.thunderbird.net" target="_blank">Maildev</a> - A moderated mailing list for Thunderbird Engineering plans.') }}
+              {{ _('<a href="http://lists.thunderbird.net/mailman/listinfo/maildev_lists.thunderbird.net">Maildev</a> - A moderated mailing list for Thunderbird Engineering plans.') }}
             </li>
             <li>
-              {{ _('<a href="https://wiki.mozilla.org/Thunderbird/tb-support-crew" target="_blank">tb-support-crew</a> - For those who help the users.') }}
+              {{ _('<a href="https://wiki.mozilla.org/Thunderbird/tb-support-crew">tb-support-crew</a> - For those who help the users.') }}
             </li>
             <li>
-              {{ _('<a href="https://mail.mozilla.org/listinfo/thunderbird-testers" target="_blank">thunderbird-testers</a> - For anyone who is helping test.') }}
+              {{ _('<a href="https://mail.mozilla.org/listinfo/thunderbird-testers">thunderbird-testers</a> - For anyone who is helping test.') }}
             </li>
             <li>
-              {{ _('<a href="https://lists.mozilla.org/listinfo/dev-apps-thunderbird" target="_blank">dev-apps-thunderbird</a> (<a href="news://news.mozilla.org/mozilla.dev.apps.thunderbird" target="_blank">Newsgroup</a>) (<a href="https://groups.google.com/forum/#!forum/mozilla.dev.apps.thunderbird" target="_blank">Google Group Mirror</a>) - For technical and code related discussions, such as add-ons.') }}
+              {{ _('<a href="https://lists.mozilla.org/listinfo/dev-apps-thunderbird">dev-apps-thunderbird</a> (<a href="news://news.mozilla.org/mozilla.dev.apps.thunderbird">Newsgroup</a>) (<a href="https://groups.google.com/forum/#!forum/mozilla.dev.apps.thunderbird">Google Group Mirror</a>) - For technical and code related discussions, such as add-ons.') }}
             </li>
             <li>
-              {{ _('<a href="https://wiki.mozilla.org/Thunderbird/tb-enterprise" target="_blank">tb-enterprise</a> - For ADMINISTRATORS to discuss large scale deployment and configuration of Thunderbird.') }}
+              {{ _('<a href="https://wiki.mozilla.org/Thunderbird/tb-enterprise">tb-enterprise</a> - For ADMINISTRATORS to discuss large scale deployment and configuration of Thunderbird.') }}
             </li>
             <li>
-              {{ _('<a href="https://thunderbird.topicbox.com/groups/addons" target="_blank">Add-on Developers List</a> - For general discussions about creating add-ons, and is for add-on developers who need support in creating their add-ons.') }}
+              {{ _('<a href="https://thunderbird.topicbox.com/groups/addons">Add-on Developers List</a> - For general discussions about creating add-ons, and is for add-on developers who need support in creating their add-ons.') }}
             </li>
           </ul>
           <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-            {{ _('Also check the <a href="https://wiki.mozilla.org/Thunderbird/CommunicationChannels" target="_blank">Communication Channels</a> wiki page.') }}
+            {{ _('Also check the <a href="https://wiki.mozilla.org/Thunderbird/CommunicationChannels">Communication Channels</a> wiki page.') }}
           </p>
         </article>
       </aside>

--- a/website/organizations/index.html
+++ b/website/organizations/index.html
@@ -25,13 +25,13 @@
           {{ _('A community-led project that allows organizations to benefit from the speed, flexibility and security of Thunderbird while getting the support they need.') }}
         </p>
         <p class="font-lg tracking-wider leading-loose mb-6 p-links-blue">
-          {{ _('The Thunderbird Extended Support Releases (ESR) are <a href="{latest}">mainstream releases</a>, operating similarly to <a href="{firefox_esr}" target="_blank">Mozilla Firefox ESR</a>. They are stable for approximately one year before receiving feature updates.')|f(latest=url('thunderbird.latest.all'), firefox_esr=url('firefox.organizations.faq')) }}
+          {{ _('The Thunderbird Extended Support Releases (ESR) are <a href="{latest}">mainstream releases</a>, operating similarly to <a href="{firefox_esr}">Mozilla Firefox ESR</a>. They are stable for approximately one year before receiving feature updates.')|f(latest=url('thunderbird.latest.all'), firefox_esr=url('firefox.organizations.faq')) }}
         </p>
         <p class="font-lg tracking-wider leading-loose mb-10 mt-0 p-links-blue">
-          {{ _('To get help or ask questions about Thunderbird visit <a href="{0}" target="_blank">Thunderbird support</a>.')|f(url('support')) }}
+          {{ _('To get help or ask questions about Thunderbird visit <a href="{0}">Thunderbird support</a>.')|f(url('support')) }}
         </p>
         <p class="font-lg tracking-wider leading-loose mb-10 mt-0 p-links-blue">
-          {{ _('You can find the Thunderbird MSI Installer on the <a href="{syslang}">Systems & Languages page</a>. For more information about deploying and configuring Thunderbird in business and enterprise environments, you can also join the <a href="{maillist}" target="_blank">Enterprise mailing list</a>.')|f(maillist=url('thunderbird.enterprise'), syslang=url('thunderbird.latest.all')) }}
+          {{ _('You can find the Thunderbird MSI Installer on the <a href="{syslang}">Systems & Languages page</a>. For more information about deploying and configuring Thunderbird in business and enterprise environments, you can also join the <a href="{maillist}">Enterprise mailing list</a>.')|f(maillist=url('thunderbird.enterprise'), syslang=url('thunderbird.latest.all')) }}
         </p>
       </aside>
     </section>

--- a/website/thunderbird/68.0/whatsnew/index.html
+++ b/website/thunderbird/68.0/whatsnew/index.html
@@ -41,7 +41,7 @@
         {{ _('Filelink attachments that have already been uploaded can now be linked to again instead of having to re-upload them. Also, an account is no longer required to use the default Filelink provider - <strong>WeTransfer</strong>.') }}
       </p>
       <p class="font-lg tracking-wider leading-loose mb-8 mt-0 flex-1 p-links-blue">
-        {{ _('Other Filelink providers like Box and Dropbox are not included by default, but can be added by grabbing the <a href="%(dropbox)s" target="_blank">Dropbox</a> and <a href="%(box)s" target="_blank">Box</a> add-ons.')|format(dropbox='https://addons.thunderbird.net/thunderbird/addon/filelink-provider-for-dropbox/',box='https://addons.thunderbird.net/thunderbird/addon/filelink-provider-for-box/') }}
+        {{ _('Other Filelink providers like Box and Dropbox are not included by default, but can be added by grabbing the <a href="%(dropbox)s">Dropbox</a> and <a href="%(box)s">Box</a> add-ons.')|format(dropbox='https://addons.thunderbird.net/thunderbird/addon/filelink-provider-for-dropbox/',box='https://addons.thunderbird.net/thunderbird/addon/filelink-provider-for-box/') }}
       </p>
     </aside>
 


### PR DESCRIPTION
I was going to add a quick JS snippet to dynamically add the `target="_blank"` attribute on page load for all the links that point externally, but I've no idea why this seems to happen already.
I cleared the cache and opened an incognito mode, and links that don't have a `target="_blank"` seem to get it automatically.

So we already have this sort of method in place somewhere?