### PR TITLE
Remove target="_blank" from templates, and add Javascript to compensate.

### DIFF
--- a/assets/js/common/base-page-init.js
+++ b/assets/js/common/base-page-init.js
@@ -12,6 +12,7 @@ $(document).ready(function() {
 
     utils.initDownloadLinks();
     utils.initMobileDownloadLinks();
+    utils.externalLinks();
     utils.initLangSwitcher();
 
     /* Bug 1264843: In partner distribution of desktop Firefox, switch the

--- a/assets/js/common/mozilla-utils.js
+++ b/assets/js/common/mozilla-utils.js
@@ -11,6 +11,7 @@ if (typeof Mozilla === 'undefined') {
     'use strict';
 
     var Utils = {};
+    var bouncerURL = 'download.mozilla.org'
 
     /**
      * Bug 393263 A special function for IE < 9.
@@ -26,6 +27,14 @@ if (typeof Mozilla === 'undefined') {
         if (link && window.site.platform === 'windows' && /MSIE\s[1-8]\./.test(ua)) {
             window.open(link, 'download_window', 'toolbar=0,location=no,directories=0,status=0,scrollbars=0,resizeable=0,width=1,height=1,top=0,left=0');
             window.focus();
+        }
+    };
+
+    // Add target="_blank" to all external links so they open in a new tab by default.
+    Utils.externalLinks = function() {
+        for (var c = document.getElementsByTagName("a"), a = 0; a < c.length; a++) {
+            var b = c[a];
+            b.getAttribute("href") && b.hostname !== location.hostname && b.hostname !== bouncerURL && (b.target = "_blank")
         }
     };
 

--- a/website/404.html
+++ b/website/404.html
@@ -6,7 +6,7 @@
 
 {% block page_title_prefix %}{{_('Thunderbird')}} — {% endblock %}
 {% block page_title %}{{ _('There’s nothing here!') }}{% endblock %}
-{% block page_desc %}{{ _('The page you are looking for doesn’t exist.<br/>If you think this is a bug, you can <a href="%(bug_report_url)s" target="_blank">report an issue here</a>.')|format(bug_report_url=url('thunderbird.site.bug-report')) }}{% endblock %}
+{% block page_desc %}{{ _('The page you are looking for doesn’t exist.<br/>If you think this is a bug, you can <a href="%(bug_report_url)s">report an issue here</a>.')|format(bug_report_url=url('thunderbird.site.bug-report')) }}{% endblock %}
 
 {% block header_content %}
   <section class="text-center text-white flex flex-col items-center xl:w-full max-w-6xl mx-auto pl-8 pr-8">

--- a/website/_includes/base-resp.html
+++ b/website/_includes/base-resp.html
@@ -25,7 +25,7 @@
       {% endblock %}
 
       {% block site_header_nav %}
-        <a href="{{ donate_url('header') }}" class="btn-donate md:hidden" target="_blank">
+        <a href="{{ donate_url('header') }}" class="btn-donate md:hidden">
           <span class="inline-block w-3 mr-1">{{ svg('heart') }}</span> {{_('Donate')}}
         </a>
         <nav id="nav-main" role="navigation" class="flex-grow md:flex-grow-0">
@@ -34,22 +34,22 @@
               <a href="{{ url('thunderbird.features') }}" class="nav-link">{{_('Features')}}</a>
             </li>
             <li>
-              <a href="https://addons.thunderbird.net" target="_blank" class="nav-link">{{_('Add-ons')}}</a>
+              <a href="https://addons.thunderbird.net" class="nav-link">{{_('Add-ons')}}</a>
             </li>
             <li>
               <a href="{{ url('thunderbird.get-involved') }}" class="nav-link">{{_('Get Involved')}}</a>
             </li>
             <li>
-              <a href="{{ url('support') }}" class="nav-link" target="_blank">{{_('Get Help')}}</a>
+              <a href="{{ url('support') }}" class="nav-link">{{_('Get Help')}}</a>
             </li>
             <li>
               <a href="{{ url('thunderbird.about') }}" class="nav-link">{{_('About Us')}}</a>
             </li>
             <li>
-              <a href="{{ url('blog') }}" class="nav-link" target="_blank">{{_('Blog')}}</a>
+              <a href="{{ url('blog') }}" class="nav-link">{{_('Blog')}}</a>
             </li>
             <li class="hidden md:inline">
-              <a href="{{ donate_url('header') }}" class="btn-donate" target="_blank">
+              <a href="{{ donate_url('header') }}" class="btn-donate">
                 <span class="inline-block w-3 mr-1">{{ svg('heart') }}</span> {{_('Donate')}}
               </a>
             </li>

--- a/website/_includes/donate-mailing-list.html
+++ b/website/_includes/donate-mailing-list.html
@@ -8,7 +8,7 @@
     <p class="font-lg tracking-wider leading-loose mb-8 mt-0 flex-1">
       {{ _('Thunderbird is both free and freedom respecting, but we’re also completely funded by donations! Help us sustain the project and continue to improve.') }}
     </p>
-    <a href="{{ donate_url('home_page_body') }}" class="btn-donate self-start ml-0 mr-0 font-lg lg:font-base" target="_blank">
+    <a href="{{ donate_url('home_page_body') }}" class="btn-donate self-start ml-0 mr-0 font-lg lg:font-base">
       <span class="inline-block w-3 mr-1">{{ svg('heart') }}</span> {{_('Donate')}}
     </a>
   </aside>
@@ -22,8 +22,7 @@
     <form action="https://mozilla.us12.list-manage.com/subscribe/post?u=f8051cc8637cf3ff79661f382&amp;id=9badb0cec2"
     class="shadow flex items-center rounded-md self-start p-1"
     method="post" id="mc-embedded-subscribe-form"
-    name="mc-embedded-subscribe-form"
-    target="_blank">
+    name="mc-embedded-subscribe-form">
     <input id="mce-EMAIL" name="EMAIL" type="email" placeholder="{{ _('Your Email') }}"
     class="w-64 appearance-none border-none p-2 tracking-wide font-semibold font-regular" required>
     <button type="submit" id="mc-embedded-subscribe" class="btn-newsletter">{{ _('Sign me up!') }}</button>

--- a/website/_includes/download-button.html
+++ b/website/_includes/download-button.html
@@ -66,6 +66,6 @@
     {% if channel != 'alpha' %}{# Earlybird release notes are not available yet #}
       <a href="{{ thunderbird_url('releasenotes', channel) }}" class="small-link {% if channel or section == 'body' %} text-blue {% endif %}">{{ _('What’s New') }}</a> &bull;
     {% endif %}
-    <a href="{{ url('privacy.notices.thunderbird') }}" class="small-link {% if channel or section == 'body' %} text-blue {% endif %}" target="_blank">{{ _('Privacy') }}</a>
+    <a href="{{ url('privacy.notices.thunderbird') }}" class="small-link {% if channel or section == 'body' %} text-blue {% endif %}">{{ _('Privacy') }}</a>
   </p>
 </div>

--- a/website/_includes/release-notes.html
+++ b/website/_includes/release-notes.html
@@ -38,7 +38,7 @@
   <section  class="pt-20 flex justify-center items-center pl-8 pr-8">
     <aside class="flex flex-col w-full max-w-6xl lg:ml-16 lg:mr-16">
       <p class="font-lg tracking-wider leading-loose mb-6 p-links-blue">
-        {{ _('Check out "What’s New" and "Known Issues" for this version of Thunderbird below. As always, you’re encouraged to <a href="%(feedback)s" target="_blank">tell us what you think</a>, or <a href="%(bugzilla)s" target="_blank">file a bug in Bugzilla</a>')|format(feedback='https://support.mozilla.org/questions/new/thunderbird', bugzilla='https://bugzilla.mozilla.org/') }}
+        {{ _('Check out "What’s New" and "Known Issues" for this version of Thunderbird below. As always, you’re encouraged to <a href="%(feedback)s">tell us what you think</a>, or <a href="%(bugzilla)s">file a bug in Bugzilla</a>')|format(feedback='https://support.mozilla.org/questions/new/thunderbird', bugzilla='https://bugzilla.mozilla.org/') }}
       </p>
       <aside class="font-lg tracking-wider leading-loose mb-6 markup-page">
         {{ release.text|markdown|safe }}

--- a/website/_includes/site-footer.html
+++ b/website/_includes/site-footer.html
@@ -9,16 +9,16 @@
       <nav id="footer-main" role="navigation" class="mt-2">
         <ul class="list-none p-0 flex flex-wrap items-center text-white nav-footer justify-around">
           <li>
-            <a href="{{ url('thunderbird.organizations') }}" class="nav-link" target="_blank">{{_('For Organizations')}}</a>
+            <a href="{{ url('thunderbird.organizations') }}" class="nav-link">{{_('For Organizations')}}</a>
           </li>
           <li>
             <a href="{{ url('thunderbird.get-involved') }}" class="nav-link">{{_('Get Involved')}}</a>
           </li>
           <li>
-            <a href="{{ url('support') }}" class="nav-link" target="_blank">{{_('Get Help')}}</a>
+            <a href="{{ url('support') }}" class="nav-link">{{_('Get Help')}}</a>
           </li>
           <li>
-            <a href="{{ url('blog') }}" class="nav-link" target="_blank">{{_('Blog')}}</a>
+            <a href="{{ url('blog') }}" class="nav-link">{{_('Blog')}}</a>
           </li>
           <li>
             <a href="{{ url('thunderbird.about') }}" class="nav-link">{{_('About Us')}}</a>
@@ -54,18 +54,18 @@
   <section class="self-center text-center max-w-xl mt-8">
     <ul class="list-none p-0 flex justify-center">
       <li class="ml-2 mr-2">
-        <a href="{{ url('privacy') }}" class="small-link" data-link-type="footer" data-link-name="Privacy" target="_blank">{{ _('Privacy') }}</a>
+        <a href="{{ url('privacy') }}" class="small-link" data-link-type="footer" data-link-name="Privacy">{{ _('Privacy') }}</a>
       </li>
       <li class="ml-2 mr-2">
-        <a href="{{ url('privacy.notices.websites') }}#cookies" class="small-link" data-link-type="footer" data-link-name="Cookies" target="_blank">{{ _('Cookies') }}</a>
+        <a href="{{ url('privacy.notices.websites') }}#cookies" class="small-link" data-link-type="footer" data-link-name="Cookies">{{ _('Cookies') }}</a>
       </li>
       <li class="ml-2 mr-2">
         <a href="{{ url('legal.index') }}" class="small-link" data-link-type="footer"
-          data-link-name="Legal" target="_blank">{{ _('Legal') }}</a>
+          data-link-name="Legal">{{ _('Legal') }}</a>
       </li>
       <li class="ml-2 mr-2">
         <a href="{{ url('legal.fraud-report') }}" class="small-link" data-link-type="footer"
-          data-link-name="Report Trademark Abuse" target="_blank">{{ _('Report Trademark Abuse') }}</a>
+          data-link-name="Report Trademark Abuse">{{ _('Report Trademark Abuse') }}</a>
       </li>
     </ul>
 
@@ -73,11 +73,11 @@
       {%- trans url=url('foundation.licensing.website-content') -%}
       Portions of this content are ©1998–{{ current_year }} by individual
       mozilla.org contributors. Content available under
-      a <a href="{{ url }}" class="inline-link" target="_blank">Creative Commons license</a>.
+      a <a href="{{ url }}" class="inline-link">Creative Commons license</a>.
       {%- endtrans -%}
     </p>
 
     <a href="{{ url('contribute') }}" class="small-link font-semibold" data-link-type="footer"
-      data-link-name="Contribute to this site" target="_blank">{{ _('Contribute to this site') }}</a>
+      data-link-name="Contribute to this site">{{ _('Contribute to this site') }}</a>
   </section>
 </footer>

--- a/website/_includes/site-prefooter.html
+++ b/website/_includes/site-prefooter.html
@@ -17,11 +17,11 @@
           {{_('Join Us')}}
         </a>
         <p class="font-sm mt-0 text-blue font-semibold self-start">
-          <a href="{{ donate_url('pre_footer') }}" class="small-link text-blue" target="_blank">{{ _('Make a Donation') }}</a> &bull;
+          <a href="{{ donate_url('pre_footer') }}" class="small-link text-blue">{{ _('Make a Donation') }}</a> &bull;
           <a href="https://support.mozilla.org/products/thunderbird/"
-            class="small-link text-blue" target="_blank">{{ _('Get Support') }}</a> &bull;
+            class="small-link text-blue">{{ _('Get Support') }}</a> &bull;
           <a href="https://bugzilla.mozilla.org/describecomponents.cgi?product=Thunderbird"
-            class="small-link text-blue" target="_blank">{{ _('Report a Bug') }}</a>
+            class="small-link text-blue">{{ _('Report a Bug') }}</a>
         </p>
       </main>
     </article>

--- a/website/about/index.html
+++ b/website/about/index.html
@@ -60,14 +60,14 @@
       <article class="flex flex-col w-full mb-6">
         <h4 class="subheader-section">{{ _('Our Community') }}</h4>
         <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-          {{ _('There is a passionate team of volunteers involved in developing Thunderbird and assisting its users who would welcome your involvement. Check out our <a href="%(volunteer)s">Get Involved page</a> to learn how you can participate on the Thunderbird team. We also have paid staff working full-time on Thunderbird, <a href="%(donate)s" target="_blank">funded by donations</a> from our users. If you’re curious about who is working on Thunderbird, check out the <a href="%(core_team)s" target="_blank">list of our core contributors</a>.')|format(volunteer=url('thunderbird.get-involved'), donate=donate_url('about'), core_team=url('wiki.moz', '/Thunderbird/Core_Team')) }}
+          {{ _('There is a passionate team of volunteers involved in developing Thunderbird and assisting its users who would welcome your involvement. Check out our <a href="%(volunteer)s">Get Involved page</a> to learn how you can participate on the Thunderbird team. We also have paid staff working full-time on Thunderbird, <a href="%(donate)s">funded by donations</a> from our users. If you’re curious about who is working on Thunderbird, check out the <a href="%(core_team)s">list of our core contributors</a>.')|format(volunteer=url('thunderbird.get-involved'), donate=donate_url('about'), core_team=url('wiki.moz', '/Thunderbird/Core_Team')) }}
         </p>
       </article>
 
       <article class="flex flex-col w-full">
         <h4 class="subheader-section">{{ _('Thunderbird Council') }}</h4>
         <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-          {{ _('The Thunderbird project is governed by seven councilors, elected by the Thunderbird community’s active contributors. You can see the current elected Thunderbird Council members <a href="%(council)s" target="_blank">on the Thunderbird wiki</a>.')|format(council=url('wiki.moz', '/Modules/Thunderbird#Thunderbird_Council')) }}
+          {{ _('The Thunderbird project is governed by seven councilors, elected by the Thunderbird community’s active contributors. You can see the current elected Thunderbird Council members <a href="%(council)s">on the Thunderbird wiki</a>.')|format(council=url('wiki.moz', '/Modules/Thunderbird#Thunderbird_Council')) }}
         </p>
       </article>
     </aside>
@@ -81,12 +81,12 @@
           <aside class="flex flex-col">
             {{ _('Thunderbird and Mozilla Foundation')}}
             <small class="font-normal font-md tracking-normal normal-case p-links-blue">
-              {{ _('Thunderbird lives at the nonprofit <a href="%(foundation)s" target="_blank">Mozilla Foundation</a>.')|format(foundation=url('foundation.about')) }}
+              {{ _('Thunderbird lives at the nonprofit <a href="%(foundation)s">Mozilla Foundation</a>.')|format(foundation=url('foundation.about')) }}
             </small>
           </aside>
         </h3>
         <p class="font-lg tracking-wider leading-loose mb-6 p-links-blue">
-          {{ _('Thunderbird is an independent project with its legal and financial home at <a href="%(foundation)s" target="_blank">the Mozilla Foundation</a>. The Mozilla Foundation believes the Internet is a global public resource that must remain open and accessible to all. It is focused on advocacy issues and keeping the Internet healthy, but is also the sole shareholder in the maker of Firefox, the Mozilla Corporation. Mozilla exerts no governance over the project, which instead falls to the Thunderbird Council, elected by the Thunderbird project’s community. The Mozilla Foundation became Thunderbird’s home after an <a href="%(home_blog_post)s" target="_blank">exploration of legal homes in 2017</a>.')|format(foundation=url('foundation.about'), home_blog_post='https://blog.mozilla.org/thunderbird/2017/05/thunderbirds-future-home/') }}
+          {{ _('Thunderbird is an independent project with its legal and financial home at <a href="%(foundation)s">the Mozilla Foundation</a>. The Mozilla Foundation believes the Internet is a global public resource that must remain open and accessible to all. It is focused on advocacy issues and keeping the Internet healthy, but is also the sole shareholder in the maker of Firefox, the Mozilla Corporation. Mozilla exerts no governance over the project, which instead falls to the Thunderbird Council, elected by the Thunderbird project’s community. The Mozilla Foundation became Thunderbird’s home after an <a href="%(home_blog_post)s">exploration of legal homes in 2017</a>.')|format(foundation=url('foundation.about'), home_blog_post='https://blog.mozilla.org/thunderbird/2017/05/thunderbirds-future-home/') }}
         </p>
       </aside>
     </section>

--- a/website/calendar/holidays/index.html
+++ b/website/calendar/holidays/index.html
@@ -26,18 +26,18 @@
         </aside>
       </h3>
       <p class="font-lg tracking-wider leading-loose mb-6 p-links-blue">
-        {{ _('We&rsquo;ve got some holiday calendar files available for download. You can either download and then import them into Sunbird or Lightning or you can just subscribe to these calendars by copying their URL and then adding them as new remote calendar files. More information on installing a holiday calendar can be found in the <a href="%s"target="_blank">Adding a holiday calendar article</a>.')|format('https://support.mozilla.org/kb/adding-a-holiday-calendar') }}
+        {{ _('We&rsquo;ve got some holiday calendar files available for download. You can either download and then import them into Sunbird or Lightning or you can just subscribe to these calendars by copying their URL and then adding them as new remote calendar files. More information on installing a holiday calendar can be found in the <a href="%s">Adding a holiday calendar article</a>.')|format('https://support.mozilla.org/kb/adding-a-holiday-calendar') }}
       </p>
       <p class="font-lg tracking-wider leading-loose mb-10 mt-0 p-links-blue">
-        {{ _('You can also find calendars to subscribe to at <a href="%s" target="_blank">iCalShare.com</a>.')|format('http://icalshare.com') }}
+        {{ _('You can also find calendars to subscribe to at <a href="%s">iCalShare.com</a>.')|format('http://icalshare.com') }}
       </p>
       <aside class="ml-0 mr-0 self-start text-left text-blue font-semibold">
-        <a href="https://addons.thunderbird.net/addon/lightning/" class="btn-join self-start" target="_blank">
+        <a href="https://addons.thunderbird.net/addon/lightning/" class="btn-join self-start">
           {{_('Download Lightning')}}
         </a>
         <p class="font-sm mt-0 text-blue font-semibold self-start">
           <a href="https://addons.thunderbird.net/addon/lightning/versions/" class="small-link text-blue"
-            target="_blank">{{ _('Other Systems &amp; Versions') }}</a>
+           >{{ _('Other Systems &amp; Versions') }}</a>
         </p>
       </aside>
     </aside>
@@ -67,12 +67,12 @@
           {% if calendar.title %}
             {% trans url=CALDATA_URL + calendar.filename, country=calendar.country,
                     title=calendar.title, authors=calendar.authors %}
-            <a href="{{ url }}" class="inline-link text-blue" target="_blank">{{ country }}</a> {{ title }}, thanks to {{ authors }}
+            <a href="{{ url }}" class="inline-link text-blue">{{ country }}</a> {{ title }}, thanks to {{ authors }}
             {% endtrans %}
           {% else %}
             {% trans url=CALDATA_URL + calendar.filename, country=calendar.country,
                     authors=calendar.authors %}
-            <a href="{{ url }}" class="inline-link text-blue" target="_blank">{{ country }}</a> holidays thanks to {{ authors }}
+            <a href="{{ url }}" class="inline-link text-blue">{{ country }}</a> holidays thanks to {{ authors }}
             {% endtrans %}
           {% endif %}
         </aside>
@@ -99,7 +99,7 @@
             {{ _('Right-click on this calendar and choose "Export Calendar". Please use the iCalendar (ics) format.') }}
           </li>
           <li class="p-links-blue">
-            {{ _('Open a bug in <a href="%s" target="_blank">Bugzilla</a>.')|format('http://bugzilla.mozilla.org/enter_bug.cgi?product=Calendar&component=Website') }}
+            {{ _('Open a bug in <a href="%s">Bugzilla</a>.')|format('http://bugzilla.mozilla.org/enter_bug.cgi?product=Calendar&component=Website') }}
           </li>
           <li>{{ _('Add your holiday file as an attachment in the new bug.') }}</li>
         </ol>

--- a/website/calendar/index.html
+++ b/website/calendar/index.html
@@ -29,12 +29,12 @@
         {{ _('Organize your schedule and life&rsquo;s important events in a calendar that&rsquo;s fully integrated with your Thunderbird or Seamonkey email. Manage multiple calendars, create your daily to do list, invite friends to events, and subscribe to public calendars.') }}
       </p>
       <aside class="ml-0 mr-0 self-start text-left text-blue font-semibold">
-        <a href="https://addons.thunderbird.net/addon/lightning/" class="btn-join self-start" target="_blank">
+        <a href="https://addons.thunderbird.net/addon/lightning/" class="btn-join self-start">
           {{_('Free Download')}}
         </a>
         <p class="font-sm mt-0 text-blue font-semibold self-start">
           <a href="https://addons.thunderbird.net/addon/lightning/versions/" class="small-link text-blue"
-            target="_blank">{{ _('Other Systems &amp; Versions') }}</a>
+           >{{ _('Other Systems &amp; Versions') }}</a>
         </p>
       </aside>
     </aside>
@@ -49,7 +49,7 @@
 
       <aside class="flex flex-col w-1/3">
         <a href="https://developer.mozilla.org/en/Calendar/Calendar_Versions"
-          class="flex flex-col btn-block-white m-2" target="_blank">
+          class="flex flex-col btn-block-white m-2">
           <h4 class="header-section mb-0">
             <span>{{ svg('information') }}</span>
             <aside class="flex flex-col font-lg">
@@ -64,7 +64,7 @@
 
       <aside class="flex flex-col w-1/3">
         <a href="https://support.mozilla.org/products/thunderbird/calendar"
-          class="flex flex-col btn-block-white m-2" target="_blank">
+          class="flex flex-col btn-block-white m-2">
           <h4 class="header-section mb-0">
             <span>{{ svg('help') }}</span>
             <aside class="flex flex-col font-lg">
@@ -93,7 +93,7 @@
 
       <aside class="flex flex-col w-1/3">
         <a href="https://developer.mozilla.org/en/Calendar/"
-          class="flex flex-col btn-block-white m-2" target="_blank">
+          class="flex flex-col btn-block-white m-2">
           <h4 class="header-section mb-0">
             <span>{{ svg('developer') }}</span>
             <aside class="flex flex-col font-lg">
@@ -108,7 +108,7 @@
 
       <aside class="flex flex-col w-1/3">
         <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Calendar"
-          class="flex flex-col btn-block-white m-2" target="_blank">
+          class="flex flex-col btn-block-white m-2">
           <h4 class="header-section mb-0">
             <span>{{ svg('warning') }}</span>
             <aside class="flex flex-col font-lg">
@@ -123,7 +123,7 @@
 
       <aside class="flex flex-col w-1/3">
         <a href="https://codetribute.mozilla.org/projects/calendar"
-          class="flex flex-col btn-block-white m-2" target="_blank">
+          class="flex flex-col btn-block-white m-2">
           <h4 class="header-section mb-0">
             <span>{{ svg('report') }}</span>
             <aside class="flex flex-col font-lg">

--- a/website/contact/index.html
+++ b/website/contact/index.html
@@ -26,16 +26,16 @@
     <section class="flex xl:w-full flex-col lg:flex-row max-w-6xl mx-auto justify-between pl-8 pr-8 mb-12 leading-relaxed">
       <article class="flex flex-col p-4 flex-1 lg:max-w-sm mb-10 lg:mb-0 bg-white rounded shadow-lg">
         <h4 class="mt-0 mb-4 uppercase text-blue font-md">
-          {{ _('<a href="%(support)s" class="header-link" target="_blank">Mozilla Support Website</a>')|format(support=url('support')) }}
+          {{ _('<a href="%(support)s" class="header-link">Mozilla Support Website</a>')|format(support=url('support')) }}
         </h4>
         <p class="mt-0 mb-6 flex-1 p-links-blue">
-          {{ _('The best place to start looking for answers if you have questions about Thunderbird is the Mozilla Support website, <a href="%(support)s" target="_blank">specifically the Thunderbird page</a>. There you can search for articles, ask questions, and read tutorials.')|format(support=url('support')) }}
+          {{ _('The best place to start looking for answers if you have questions about Thunderbird is the Mozilla Support website, <a href="%(support)s">specifically the Thunderbird page</a>. There you can search for articles, ask questions, and read tutorials.')|format(support=url('support')) }}
         </p>
       </article>
 
       <article class="flex flex-col p-4 flex-1 lg:max-w-sm mb-10 lg:mb-0 bg-white rounded shadow-lg lg:ml-16 lg:mr-16">
         <h4 class="mt-0 mb-4 uppercase text-blue font-md">
-          {{ _('<a href="https://support.mozilla.org/questions/new/thunderbird" class="header-link" target="_blank">Ask a Question</a>') }}
+          {{ _('<a href="https://support.mozilla.org/questions/new/thunderbird" class="header-link">Ask a Question</a>') }}
         </h4>
         <p class="mt-0 mb-6 flex-1">
           {{ _('You can ask a question on the support website. <b>Remember to be courteous</b>, as most of the people providing support on this site are volunteers and fellow Thunderbird users like you!') }}
@@ -44,10 +44,10 @@
 
       <article class="flex flex-col p-4 flex-1 lg:max-w-sm mb-10 lg:mb-0 bg-white rounded shadow-lg">
         <h4 class="mt-0 mb-4 uppercase text-blue font-md">
-          {{ _('<a href="irc://irc.mozilla.org/thunderbird" class="header-link" target="_blank">Live Chat on IRC</a>') }}
+          {{ _('<a href="irc://irc.mozilla.org/thunderbird" class="header-link">Live Chat on IRC</a>') }}
         </h4>
         <p class="mt-0 mb-6 flex-1 p-links-blue">
-          {{ _('You can chat with other users and members of the Thunderbird team on the <a href="irc://irc.mozilla.org/thunderbird" target="_blank">#thunderbird channel on Mozilla’s IRC</a>. You can set up IRC in Thunderbird by following the <a href="https://support.mozilla.org/kb/instant-messaging-and-chat#w_configuring-chat" target="_blank">instructions on SUMO</a>.') }}
+          {{ _('You can chat with other users and members of the Thunderbird team on the <a href="irc://irc.mozilla.org/thunderbird">#thunderbird channel on Mozilla’s IRC</a>. You can set up IRC in Thunderbird by following the <a href="https://support.mozilla.org/kb/instant-messaging-and-chat#w_configuring-chat">instructions on SUMO</a>.') }}
         </p>
       </article>
     </section>
@@ -59,7 +59,7 @@
         <article class="flex flex-col w-full mb-6 lg:pr-8">
           <h4 class="subheader-section">{{ _('Security') }}</h4>
           <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-            {{ _('To report a security issue related to Thunderbird, please register an account at <a href="https://bugzilla.mozilla.org/" target="_blank">Bugzilla</a>, and describe the issue in a new Thunderbird <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Thunderbird" target="_blank">bug report</a>. If you select the <i>Security checkmark</i> before you submit, then only members of our security team will have access to your report.') }}
+            {{ _('To report a security issue related to Thunderbird, please register an account at <a href="https://bugzilla.mozilla.org/">Bugzilla</a>, and describe the issue in a new Thunderbird <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Thunderbird">bug report</a>. If you select the <i>Security checkmark</i> before you submit, then only members of our security team will have access to your report.') }}
           </p>
           <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
             {{ _('Bugzilla is also our preferred medium for coordinating the disclosure of security incidents and for discussing embargo dates. If you don’t get a timely response in Bugzilla, please contact us at <a href="mailto:security@thunderbird.net">security@thunderbird.net</a> and mention the respective bug numbers. Encrypted email can be arranged on demand.') }}

--- a/website/get-involved/index.html
+++ b/website/get-involved/index.html
@@ -76,7 +76,7 @@
           </aside>
         </h3>
         <p class="font-lg tracking-wider leading-loose mb-6 p-links-blue">
-          {{ _('If you would like to learn how to contribute code to Thunderbird, check out our <a href="https://developer.thunderbird.net/" target="_blank">developer documentation.</a> You will learn how to get the code, set any necessary configuration, build the calendar, rebuild after checking out new code, etc. It is a good read. Don’t just skim it.') }}
+          {{ _('If you would like to learn how to contribute code to Thunderbird, check out our <a href="https://developer.thunderbird.net/">developer documentation.</a> You will learn how to get the code, set any necessary configuration, build the calendar, rebuild after checking out new code, etc. It is a good read. Don’t just skim it.') }}
         </p>
       </aside>
     </section>
@@ -90,13 +90,13 @@
           </p>
           <ul class="font-md tracking-wider leading-loose mb-10 p-links-blue">
             <li>
-              {{ _('<a href="https://hg.mozilla.org/comm-central/" target="_blank">comm-central</a> is the main Thunderbird repository.') }}
+              {{ _('<a href="https://hg.mozilla.org/comm-central/">comm-central</a> is the main Thunderbird repository.') }}
             </li>
             <li>
-              {{ _('Thunderbird also relies on the code from <a href="https://hg.mozilla.org/mozilla-central/" target="_blank">mozilla-central</a>. See the <a href="https://developer.thunderbird.net/the-basics/building-thunderbird" target="_blank">build instructions</a> for how to obtain all the code needed to build.') }}
+              {{ _('Thunderbird also relies on the code from <a href="https://hg.mozilla.org/mozilla-central/">mozilla-central</a>. See the <a href="https://developer.thunderbird.net/the-basics/building-thunderbird">build instructions</a> for how to obtain all the code needed to build.') }}
             </li>
             <li>
-              {{ _('You can search the code on <a href="https://searchfox.org/comm-central/source" target="_blank">SearchFox</a>.') }}
+              {{ _('You can search the code on <a href="https://searchfox.org/comm-central/source">SearchFox</a>.') }}
             </li>
           </ul>
           <p class="font-md tracking-wide leading-loose mt-0 mb-0">
@@ -104,10 +104,10 @@
           </p>
           <ul class="font-md tracking-wider leading-loose mb-6 p-links-blue">
             <li>
-              {{ _('<a href="https://github.com/thundernest" target="_blank">Thundernest</a> contains the code for Thunderbird.net (this site), as well as the Thunderbird web server setup scripts.') }}
+              {{ _('<a href="https://github.com/thundernest">Thundernest</a> contains the code for Thunderbird.net (this site), as well as the Thunderbird web server setup scripts.') }}
             </li>
             <li>
-              {{ _('<a href="https://github.com/mozilla-comm" target="_blank">Thunderbird on GitHub</a> contains several Thunderbird related repositories.') }}
+              {{ _('<a href="https://github.com/mozilla-comm">Thunderbird on GitHub</a> contains several Thunderbird related repositories.') }}
             </li>
           </ul>
         </article>
@@ -117,20 +117,20 @@
         <article class="flex flex-col mb-6 lg:pl-8">
           <h4 class="subheader-section">{{ _('Bugs') }}</h4>
           <p class="font-md tracking-wide leading-loose mb-0 mt-0 p-links-blue">
-            {{ _('All Thunderbird bugs live on <a href="https://bugzilla.mozilla.org" target="_blank">Mozilla’s Bugzilla</a>. Bugzilla is a powerful tool and can be intimidating if you are not used to it. So check out these pre-defined searches to test the waters:') }}
+            {{ _('All Thunderbird bugs live on <a href="https://bugzilla.mozilla.org">Mozilla’s Bugzilla</a>. Bugzilla is a powerful tool and can be intimidating if you are not used to it. So check out these pre-defined searches to test the waters:') }}
           </p>
           <ul class="font-md tracking-wider leading-loose mb-6 p-links-blue">
             <li>
-              {{ _('You can help out by triaging <a href="https://bugzilla.mozilla.org/buglist.cgi?list_id=14114741&chfieldto=Now&query_format=advanced&chfield=%5BBug%20creation%5D&chfieldfrom=-3d&product=MailNews%20Core&product=Thunderbird" target="_blank">incoming bugs</a>. Known bugs should be marked as duplicates, unconfirmed bugs often needs someone to see if they too can reproduce.') }}
+              {{ _('You can help out by triaging <a href="https://bugzilla.mozilla.org/buglist.cgi?list_id=14114741&chfieldto=Now&query_format=advanced&chfield=%5BBug%20creation%5D&chfieldfrom=-3d&product=MailNews%20Core&product=Thunderbird">incoming bugs</a>. Known bugs should be marked as duplicates, unconfirmed bugs often needs someone to see if they too can reproduce.') }}
               </li>
             <li>
-              {{ _('<a href="https://mzl.la/2oijxOd" target="_blank">"Good first bugs"</a> which are extra easy to try and fix when you are just starting out.') }}
+              {{ _('<a href="https://mzl.la/2oijxOd">"Good first bugs"</a> which are extra easy to try and fix when you are just starting out.') }}
             </li>
             <li>
-              {{ _('<a href="http://www.joshmatthews.net/bugsahoy/?thunderbird=1" target="_blank">Mentored Bugs</a> have a mentor who commits to helping you every step of the way.') }}
+              {{ _('<a href="http://www.joshmatthews.net/bugsahoy/?thunderbird=1">Mentored Bugs</a> have a mentor who commits to helping you every step of the way.') }}
             </li>
             <li>
-              {{ _('<a href="https://wiki.mozilla.org/Thunderbird:Bug_Queries" target="_blank">Thunderbird bug queries</a> is a wiki page with lots of useful searches.') }}
+              {{ _('<a href="https://wiki.mozilla.org/Thunderbird:Bug_Queries">Thunderbird bug queries</a> is a wiki page with lots of useful searches.') }}
             </li>
           </ul>
         </article>
@@ -139,7 +139,7 @@
       <aside class="flex flex-col">
         <h4 class="subheader-section">{{ _('Add-Ons') }}</h4>
         <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-          {{ _('Learn how to create add-ons and themes by checking out our <a href="https://developer.thunderbird.net/add-ons/about-add-ons" target="_blank">developer documentation. </a>') }}
+          {{ _('Learn how to create add-ons and themes by checking out our <a href="https://developer.thunderbird.net/add-ons/about-add-ons">developer documentation. </a>') }}
         </p>
       </aside>
     </section>
@@ -158,14 +158,14 @@
           </aside>
         </h3>
         <p class="font-lg tracking-wider leading-loose mb-6 p-links-blue">
-          {{ _('Please share ideas and concepts by posting them on <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Thunderbird&bug_severity=enhancement" target="_blank">Bugzilla</a>.<br/>You can also discuss design in the <a href="irc://irc.mozilla.org/maildev" target="_blank">#maildev</a> irc channel, or the <a href="https://discourse.mozilla.org/c/thunderbird" target="_blank">Discourse category</a>.') }}
+          {{ _('Please share ideas and concepts by posting them on <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Thunderbird&bug_severity=enhancement">Bugzilla</a>.<br/>You can also discuss design in the <a href="irc://irc.mozilla.org/maildev">#maildev</a> irc channel, or the <a href="https://discourse.mozilla.org/c/thunderbird">Discourse category</a>.') }}
         </p>
       </aside>
 
       <aside class="flex flex-col w-full lg:w-1/2 lg:mt-20">
         <h4 class="subheader-section">{{ _('Style Guide') }}</h4>
         <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-          {{ _('Looking for the Thunderbird logo, icons, color palette, or other design resources? Check out our <a href="%(style_guide)s" target="_blank">style guide</a>.')|format(style_guide=url('thunderbird.style')) }}
+          {{ _('Looking for the Thunderbird logo, icons, color palette, or other design resources? Check out our <a href="%(style_guide)s">style guide</a>.')|format(style_guide=url('thunderbird.style')) }}
         </p>
       </aside>
     </section>
@@ -189,10 +189,10 @@
         <h4 class="subheader-section">{{ _('Where documentation lives') }}</h4>
         <ul class="font-md tracking-wider leading-loose mb-10 p-links-blue">
           <li>
-            {{ _('<a href="https://wiki.mozilla.org/Thunderbird:Home" target="_blank">The Thunderbird section</a> of the Mozilla wiki.') }}
+            {{ _('<a href="https://wiki.mozilla.org/Thunderbird:Home">The Thunderbird section</a> of the Mozilla wiki.') }}
           </li>
           <li>
-            {{ _('The official <a href="https://developer.thunderbird.net/" target="_blank">Thunderbird developer website.</a>') }}
+            {{ _('The official <a href="https://developer.thunderbird.net/">Thunderbird developer website.</a>') }}
           </li>
         </ul>
       </article>
@@ -203,13 +203,13 @@
         <h4 class="subheader-section">{{ _('Contributing to documentation') }}</h4>
         <ul class="font-md tracking-wider leading-loose mb-6 p-links-blue">
           <li>
-            {{ _('<a href="https://wiki.mozilla.org/MozillaWiki:Policies/Accounts" target="_blank">MozillaWiki:Policies/Accounts</a> - What you need to know to contribute to the wiki. That page is applicable to the Thunderbird section.') }}
+            {{ _('<a href="https://wiki.mozilla.org/MozillaWiki:Policies/Accounts">MozillaWiki:Policies/Accounts</a> - What you need to know to contribute to the wiki. That page is applicable to the Thunderbird section.') }}
           </li>
           <li>
-            {{ _('You can contribute to the Thunderbird developer documentation via its repository <a href="https://github.com/thundernest/developer-docs" target="_blank"> on GitHub.</a>') }}
+            {{ _('You can contribute to the Thunderbird developer documentation via its repository <a href="https://github.com/thundernest/developer-docs"> on GitHub.</a>') }}
           </li>
           <li>
-            {{ _('Support users asking for help on the <a href="https://support.mozilla.org/en-US/questions/thunderbird" target="_blank">Thunderbird Support Forum</a>') }}
+            {{ _('Support users asking for help on the <a href="https://support.mozilla.org/en-US/questions/thunderbird">Thunderbird Support Forum</a>') }}
           </li>
         </ul>
       </article>
@@ -229,7 +229,7 @@
           </aside>
         </h3>
         <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-          {{ _('See <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Thunderbird/Thunderbird_Localization" target="_blank">Thunderbird Localization</a> on MDN.') }}
+          {{ _('See <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Thunderbird/Thunderbird_Localization">Thunderbird Localization</a> on MDN.') }}
         </p>
       </article>
     </aside>
@@ -246,7 +246,7 @@
           </aside>
         </h3>
         <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-          {{ _('See <a href="https://wiki.mozilla.org/Thunderbird:Testing" target="_blank">Thunderbird:Testing</a> on the Mozilla Wiki.') }}
+          {{ _('See <a href="https://wiki.mozilla.org/Thunderbird:Testing">Thunderbird:Testing</a> on the Mozilla Wiki.') }}
         </p>
       </article>
     </aside>
@@ -270,26 +270,26 @@
         <article class="flex flex-col w-full mb-6 lg:pl-8">
           <h4 class="subheader-section">{{ _('Discussion Forums') }}</h4>
           <ul class="font-md tracking-wider leading-loose mb-6 p-links-blue">
-            <li>{{ _('<a href="https://support.mozilla.org/en-US/questions/thunderbird" target="_blank">Thunderbird Support Forum</a>') }}
+            <li>{{ _('<a href="https://support.mozilla.org/en-US/questions/thunderbird">Thunderbird Support Forum</a>') }}
             </li>
             <li>
-              {{ _('<a href="https://discourse.mozilla.org/" target="_blank">Mozilla’s Discourse</a>') }}
+              {{ _('<a href="https://discourse.mozilla.org/">Mozilla’s Discourse</a>') }}
               <ul>
                 <li>
-                  {{ _('<a href="https://discourse.mozilla.org/c/thunderbird" target="_blank">Thunderbird</a>') }}</li>
+                  {{ _('<a href="https://discourse.mozilla.org/c/thunderbird">Thunderbird</a>') }}</li>
                 <li>
-                  {{ _('<a href="https://discourse.mozilla.org/c/thunderbird/beta" target="_blank">Thunderbird Beta</a>') }}
+                  {{ _('<a href="https://discourse.mozilla.org/c/thunderbird/beta">Thunderbird Beta</a>') }}
                 </li>
                 <li>
-                  {{ _('<a href="https://discourse.mozilla.org/c/thunderbird/addons" target="_blank">Thunderbird Add-Ons</a>') }}
+                  {{ _('<a href="https://discourse.mozilla.org/c/thunderbird/addons">Thunderbird Add-Ons</a>') }}
                 </li>
               </ul>
             </li>
             <li>
-              {{ _('<a href="http://forums.mozillazine.org/viewforum.php?f=29" target="_blank">Thunderbird Builds</a> on MozillaZine - For help with building Thunderbird and using daily builds.') }}
+              {{ _('<a href="http://forums.mozillazine.org/viewforum.php?f=29">Thunderbird Builds</a> on MozillaZine - For help with building Thunderbird and using daily builds.') }}
             </li>
             <li>
-              {{ _('<a href="https://groups.google.com/forum/#!forum/mozilla.support.thunderbird" target="_blank">mozilla.support.thunderbird</a> is a Google Group for support.')}}
+              {{ _('<a href="https://groups.google.com/forum/#!forum/mozilla.support.thunderbird">mozilla.support.thunderbird</a> is a Google Group for support.')}}
             </li>
           </ul>
         </article>
@@ -299,19 +299,19 @@
         <article class="flex flex-col w-full mb-6 lg:pl-8">
           <h4 class="subheader-section">{{ _('IRC Channels on irc.mozilla.org') }}</h4>
           <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-            {{ _('You can use <a href="https://mibbit.com/" target="_blank">Mibbit.com</a> if you don’t already have a preferred IRC client..') }}
+            {{ _('You can use <a href="https://mibbit.com/">Mibbit.com</a> if you don’t already have a preferred IRC client..') }}
           </p>
           <ul class="font-md tracking-wider leading-loose mb-6 p-links-blue">
             <li>
-              {{ _('<a href="irc://irc.mozilla.org/maildev" target="_blank">#maildev</a> - For hacking on Thunderbird.') }}</li>
+              {{ _('<a href="irc://irc.mozilla.org/maildev">#maildev</a> - For hacking on Thunderbird.') }}</li>
             <li>
-              {{ _('<a href="irc://irc.mozilla.org/extdev" target="_blank">#extdev</a> - For building Thunderbird add-ons/extensions.') }}
+              {{ _('<a href="irc://irc.mozilla.org/extdev">#extdev</a> - For building Thunderbird add-ons/extensions.') }}
             </li>
             <li>
-              {{ _('<a href="irc://irc.mozilla.org/thunderbird" target="_blank">#thunderbird</a> - For general questions and support.') }}
+              {{ _('<a href="irc://irc.mozilla.org/thunderbird">#thunderbird</a> - For general questions and support.') }}
             </li>
             <li>
-              {{ _('<a href="irc://irc.mozilla.org/tb-qa" target="_blank">#tb-qa</a> - For QA chat.') }}</li>
+              {{ _('<a href="irc://irc.mozilla.org/tb-qa">#tb-qa</a> - For QA chat.') }}</li>
           </ul>
         </article>
       </aside>
@@ -321,29 +321,29 @@
           <h4 class="subheader-section">{{ _('Mailing Lists') }}</h4>
           <ul class="font-md tracking-wider leading-loose mb-6 p-links-blue">
             <li>
-              {{ _('<a href="https://wiki.mozilla.org/Thunderbird/tb-planning" target="_blank">tb-planning</a> (<a href="https://groups.google.com/forum/#!forum/tb-planning" target="_blank">Google Group Mirror</a>) - For high level topics.') }}
+              {{ _('<a href="https://wiki.mozilla.org/Thunderbird/tb-planning">tb-planning</a> (<a href="https://groups.google.com/forum/#!forum/tb-planning">Google Group Mirror</a>) - For high level topics.') }}
             </li>
             <li>
-              {{ _('<a href="http://lists.thunderbird.net/mailman/listinfo/maildev_lists.thunderbird.net" target="_blank">Maildev</a> - A moderated mailing list for Thunderbird Engineering plans.') }}
+              {{ _('<a href="http://lists.thunderbird.net/mailman/listinfo/maildev_lists.thunderbird.net">Maildev</a> - A moderated mailing list for Thunderbird Engineering plans.') }}
             </li>
             <li>
-              {{ _('<a href="https://wiki.mozilla.org/Thunderbird/tb-support-crew" target="_blank">tb-support-crew</a> - For those who help the users.') }}
+              {{ _('<a href="https://wiki.mozilla.org/Thunderbird/tb-support-crew">tb-support-crew</a> - For those who help the users.') }}
             </li>
             <li>
-              {{ _('<a href="https://mail.mozilla.org/listinfo/thunderbird-testers" target="_blank">thunderbird-testers</a> - For anyone who is helping test.') }}
+              {{ _('<a href="https://mail.mozilla.org/listinfo/thunderbird-testers">thunderbird-testers</a> - For anyone who is helping test.') }}
             </li>
             <li>
-              {{ _('<a href="https://lists.mozilla.org/listinfo/dev-apps-thunderbird" target="_blank">dev-apps-thunderbird</a> (<a href="news://news.mozilla.org/mozilla.dev.apps.thunderbird" target="_blank">Newsgroup</a>) (<a href="https://groups.google.com/forum/#!forum/mozilla.dev.apps.thunderbird" target="_blank">Google Group Mirror</a>) - For technical and code related discussions, such as add-ons.') }}
+              {{ _('<a href="https://lists.mozilla.org/listinfo/dev-apps-thunderbird">dev-apps-thunderbird</a> (<a href="news://news.mozilla.org/mozilla.dev.apps.thunderbird">Newsgroup</a>) (<a href="https://groups.google.com/forum/#!forum/mozilla.dev.apps.thunderbird">Google Group Mirror</a>) - For technical and code related discussions, such as add-ons.') }}
             </li>
             <li>
-              {{ _('<a href="https://wiki.mozilla.org/Thunderbird/tb-enterprise" target="_blank">tb-enterprise</a> - For ADMINISTRATORS to discuss large scale deployment and configuration of Thunderbird.') }}
+              {{ _('<a href="https://wiki.mozilla.org/Thunderbird/tb-enterprise">tb-enterprise</a> - For ADMINISTRATORS to discuss large scale deployment and configuration of Thunderbird.') }}
             </li>
             <li>
-              {{ _('<a href="https://thunderbird.topicbox.com/groups/addons" target="_blank">Add-on Developers List</a> - For general discussions about creating add-ons, and is for add-on developers who need support in creating their add-ons.') }}
+              {{ _('<a href="https://thunderbird.topicbox.com/groups/addons">Add-on Developers List</a> - For general discussions about creating add-ons, and is for add-on developers who need support in creating their add-ons.') }}
             </li>
           </ul>
           <p class="font-md tracking-wide leading-loose mb-6 mt-0 p-links-blue">
-            {{ _('Also check the <a href="https://wiki.mozilla.org/Thunderbird/CommunicationChannels" target="_blank">Communication Channels</a> wiki page.') }}
+            {{ _('Also check the <a href="https://wiki.mozilla.org/Thunderbird/CommunicationChannels">Communication Channels</a> wiki page.') }}
           </p>
         </article>
       </aside>

--- a/website/index.html
+++ b/website/index.html
@@ -73,7 +73,7 @@
 
           {% for x in range(3): %}
             <article class="flex flex-col p-4 flex-1 lg:max-w-sm bg-white rounded shadow-lg{% if x != 2 %} mb-10 lg:mb-0{% endif %}{% if x == 1 %} lg:ml-16 lg:mr-16{% endif %}">
-              <a class="blog-link" href="{{ get_blog_data(x)['link'] }}" target="_blank" title="Continue Reading {{ get_blog_data(x)['title'] }}">
+              <a class="blog-link" href="{{ get_blog_data(x)['link'] }}" title="Continue Reading {{ get_blog_data(x)['title'] }}">
                 {{ get_blog_data(x)['title'] }}
               </a>
               <p class="blog-body">
@@ -89,7 +89,7 @@
         </section>
       {% endif %}
 
-      <a href="{{ url('blog') }}" class="btn-body mb-10" target="_blank">{{_('Read the Blog')}}
+      <a href="{{ url('blog') }}" class="btn-body mb-10">{{_('Read the Blog')}}
         <span>{{ svg('chevron-right') }}</span>
       </a>
     </section>
@@ -123,7 +123,7 @@
           <a href="{{ url('calendar') }}" class="btn-body">{{_('Explore Features')}}
             <span>{{ svg('chevron-right') }}</span>
           </a>
-          <a href="https://addons.thunderbird.net" class="btn-body btn-secondary ml-4" target="_blank">{{_('Explore More Add-ons')}}
+          <a href="https://addons.thunderbird.net" class="btn-body btn-secondary ml-4">{{_('Explore More Add-ons')}}
             <span>{{ svg('chevron-right') }}</span>
           </a>
         </p>

--- a/website/organizations/index.html
+++ b/website/organizations/index.html
@@ -25,13 +25,13 @@
           {{ _('A community-led project that allows organizations to benefit from the speed, flexibility and security of Thunderbird while getting the support they need.') }}
         </p>
         <p class="font-lg tracking-wider leading-loose mb-6 p-links-blue">
-          {{ _('The Thunderbird Extended Support Releases (ESR) are <a href="{latest}">mainstream releases</a>, operating similarly to <a href="{firefox_esr}" target="_blank">Mozilla Firefox ESR</a>. They are stable for approximately one year before receiving feature updates.')|f(latest=url('thunderbird.latest.all'), firefox_esr=url('firefox.organizations.faq')) }}
+          {{ _('The Thunderbird Extended Support Releases (ESR) are <a href="{latest}">mainstream releases</a>, operating similarly to <a href="{firefox_esr}">Mozilla Firefox ESR</a>. They are stable for approximately one year before receiving feature updates.')|f(latest=url('thunderbird.latest.all'), firefox_esr=url('firefox.organizations.faq')) }}
         </p>
         <p class="font-lg tracking-wider leading-loose mb-10 mt-0 p-links-blue">
-          {{ _('To get help or ask questions about Thunderbird visit <a href="{0}" target="_blank">Thunderbird support</a>.')|f(url('support')) }}
+          {{ _('To get help or ask questions about Thunderbird visit <a href="{0}">Thunderbird support</a>.')|f(url('support')) }}
         </p>
         <p class="font-lg tracking-wider leading-loose mb-10 mt-0 p-links-blue">
-          {{ _('You can find the Thunderbird MSI Installer on the <a href="{syslang}">Systems & Languages page</a>. For more information about deploying and configuring Thunderbird in business and enterprise environments, you can also join the <a href="{maillist}" target="_blank">Enterprise mailing list</a>.')|f(maillist=url('thunderbird.enterprise'), syslang=url('thunderbird.latest.all')) }}
+          {{ _('You can find the Thunderbird MSI Installer on the <a href="{syslang}">Systems & Languages page</a>. For more information about deploying and configuring Thunderbird in business and enterprise environments, you can also join the <a href="{maillist}">Enterprise mailing list</a>.')|f(maillist=url('thunderbird.enterprise'), syslang=url('thunderbird.latest.all')) }}
         </p>
       </aside>
     </section>

--- a/website/thunderbird/68.0/whatsnew/index.html
+++ b/website/thunderbird/68.0/whatsnew/index.html
@@ -41,7 +41,7 @@
         {{ _('Filelink attachments that have already been uploaded can now be linked to again instead of having to re-upload them. Also, an account is no longer required to use the default Filelink provider - <strong>WeTransfer</strong>.') }}
       </p>
       <p class="font-lg tracking-wider leading-loose mb-8 mt-0 flex-1 p-links-blue">
-        {{ _('Other Filelink providers like Box and Dropbox are not included by default, but can be added by grabbing the <a href="%(dropbox)s" target="_blank">Dropbox</a> and <a href="%(box)s" target="_blank">Box</a> add-ons.')|format(dropbox='https://addons.thunderbird.net/thunderbird/addon/filelink-provider-for-dropbox/',box='https://addons.thunderbird.net/thunderbird/addon/filelink-provider-for-box/') }}
+        {{ _('Other Filelink providers like Box and Dropbox are not included by default, but can be added by grabbing the <a href="%(dropbox)s">Dropbox</a> and <a href="%(box)s">Box</a> add-ons.')|format(dropbox='https://addons.thunderbird.net/thunderbird/addon/filelink-provider-for-dropbox/',box='https://addons.thunderbird.net/thunderbird/addon/filelink-provider-for-box/') }}
       </p>
     </aside>
 

--- a/website/thunderbird/releases/index.html
+++ b/website/thunderbird/releases/index.html
@@ -44,17 +44,17 @@
 
         <aside class="flex flex-col lg:flex-row flex-wrap items-center bg-white shadow-md mb-4 rounded">
           <h4 class="font-2xl font-bold m-0 p-3 lg:w-24">
-            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.1.html" class="inline-link text-blue-dark font-bold no-underline" target="_blank">0.1</a>
+            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.1.html" class="inline-link text-blue-dark font-bold no-underline">0.1</a>
           </h4>
           <aside class="flex-1 p-3">
-            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.2.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release" target="_blank">0.2</a>
-            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.3.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release" target="_blank">0.3</a>
-            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.4.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release" target="_blank">0.4</a>
-            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.5.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release" target="_blank">0.5</a>
-            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.6.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release" target="_blank">0.6</a>
-            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.7.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release" target="_blank">0.7</a>
-            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.8.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release" target="_blank">0.8</a>
-            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.9.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release" target="_blank">0.9</a>
+            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.2.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release">0.2</a>
+            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.3.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release">0.3</a>
+            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.4.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release">0.4</a>
+            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.5.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release">0.5</a>
+            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.6.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release">0.6</a>
+            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.7.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release">0.7</a>
+            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.8.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release">0.8</a>
+            <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/0.9.html" class="inline-link text-blue-dark font-bold no-underline btn-body btn-secondary btn-release">0.9</a>
           </aside>
         </aside>
       </aside>
@@ -68,15 +68,15 @@
 {% macro get_link(int_version, version, point_release = false) %}
   {% set class = ' btn-body btn-secondary btn-release' if point_release else '' %}
   {%- if int_version < 2 -%}
-    <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/{{ version }}.html" class="inline-link text-blue-dark font-bold no-underline{{ class }}" target="_blank">{{ version }}</a>
+    <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/releases/{{ version }}.html" class="inline-link text-blue-dark font-bold no-underline{{ class }}">{{ version }}</a>
   {%- elif version == '2.0' -%}
-    <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/2.0.0.0/releasenotes/" class="inline-link text-blue-dark font-bold no-underline{{ class }}" target="_blank">{{ version }}</a>
+    <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/2.0.0.0/releasenotes/" class="inline-link text-blue-dark font-bold no-underline{{ class }}">{{ version }}</a>
   {%- elif version == '17.0.9' -%}
-    <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/17.0.9esr/releasenotes/" class="inline-link text-blue-dark font-bold no-underline{{ class }}" target="_blank">{{ version }}</a>
+    <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/17.0.9esr/releasenotes/" class="inline-link text-blue-dark font-bold no-underline{{ class }}">{{ version }}</a>
   {%- elif version == '17.0.10' -%}
-    <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/17.0.10esr/releasenotes/" class="inline-link text-blue-dark font-bold no-underline{{ class }}" target="_blank">{{ version }}</a>
+    <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/17.0.10esr/releasenotes/" class="inline-link text-blue-dark font-bold no-underline{{ class }}">{{ version }}</a>
   {%- elif int_version < 31 -%}
-    <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/{{ version }}/releasenotes/" class="inline-link text-blue-dark font-bold no-underline{{ class }}" target="_blank">{{ version }}</a>
+    <a href="http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/{{ version }}/releasenotes/" class="inline-link text-blue-dark font-bold no-underline{{ class }}">{{ version }}</a>
   {%- else -%}
     <a href="../../../en-US/thunderbird/{{ version }}/releasenotes/" class="inline-link text-blue-dark font-bold no-underline{{ class }}">{{ version }}</a>
   {%- endif -%}


### PR DESCRIPTION
`var bouncerURL = 'download.mozilla.org'` should probably be automatically set by the Python, so that this isn't duplicated, but it needs to be there because adding target="_blank" to the download URLs makes them janky in Firefox at least, it opens a new tab and then closes it immediately.

If this patch is good I'll add a follow-up commit for that tomorrow.