### PR TITLE
Fix style of form-select on non-Mozilla browsers

### DIFF
--- a/assets/less/components/forms.less
+++ b/assets/less/components/forms.less
@@ -4,6 +4,7 @@
 
 .appearance-none {
   -moz-appearance: none;
+  -webkit-appearance: none;
   appearance: none;
 }
 


### PR DESCRIPTION
https://caniuse.com/#feat=css-appearance shows all other browsers support `-webkit-` prefix other than `-moz-`, or support nothing at all.

On WebKit browsers, there're 2 arrow on the right of `<select>`, one is from user agent (which is not hidden).