### PR TITLE
Add latest version to data attribute on download pages.

### DIFF
--- a/build-site.py
+++ b/build-site.py
@@ -33,20 +33,22 @@ else:
     print 'Rendering www.thunderbird.net ' + langmsg
     # Prepare data and build main website.
     version = helper.thunderbird_desktop.latest_version('release')
+    beta_version = helper.thunderbird_desktop.latest_version('beta')
     caldata = helper.load_calendar_json('media/caldata/calendars.json')
     context = {'current_year': date.today().year,
                'platform': 'desktop',
                'query': '',
                'platforms': helper.thunderbird_desktop.platforms('release'),
                'full_builds_version': version.split('.', 1)[0],
-               'full_builds': helper.thunderbird_desktop.get_filtered_full_builds('release', helper.thunderbird_desktop.latest_version()),
-               'full_builds_beta': helper.thunderbird_desktop.get_filtered_full_builds('beta', helper.thunderbird_desktop.latest_version('beta')),
+               'full_builds': helper.thunderbird_desktop.get_filtered_full_builds('release', version),
+               'full_builds_beta': helper.thunderbird_desktop.get_filtered_full_builds('beta', beta_version),
                'channel_label': 'Thunderbird',
                'releases': helper.thunderbird_desktop.list_releases(),
                'calendars': caldata['calendars'],
                'letters': caldata['letters'],
                'CALDATA_URL': settings.CALDATA_URL,
                'latest_thunderbird_version': version,
+               'latest_thunderbird_beta_version': beta_version,
                'blog_data': feedparser.parse(settings.BLOG_FEED_URL)
               }
 

--- a/website/thunderbird/all/index.html
+++ b/website/thunderbird/all/index.html
@@ -79,7 +79,7 @@
     </section>
   </section>
 
-  <section class="pb-10 w-full bg-grey-lighter">
+  <section id="all-downloads" class="pb-10 w-full bg-grey-lighter" data-thunderbird-version="{{ latest_thunderbird_version }}">
     <section class="flex max-w-6xl mx-auto pl-8 pr-8">
       <aside class="flex flex-col w-full pr-8 pl-8">
         {{ build_table(platforms, full_builds) }}

--- a/website/thunderbird/beta/all/index.html
+++ b/website/thunderbird/beta/all/index.html
@@ -75,7 +75,7 @@
     </section>
   </section>
 
-  <section class="pb-10 w-full bg-grey-lighter">
+  <section id="all-downloads" class="pb-10 w-full bg-grey-lighter" data-thunderbird-version="{{ latest_thunderbird_beta_version }}">
     <section class="flex max-w-6xl mx-auto pl-8 pr-8">
       <aside class="flex flex-col w-full pr-8 pl-8">
         {{ build_table(platforms, full_builds_beta) }}


### PR DESCRIPTION
I'm working on adding support for Thunderbird to Pollbot (https://github.com/mozilla/PollBot)
with the goal of having something similar to https://mozilla.github.io/delivery-dashboard/.

One feature of Pollbot is it scrapes the latest Firefox version out of the various download
pages on www.mozilla.org in order to check that it matches what's provided by product-details.
The easiest way to do that is to have a data attribute somewhere in the page. To make it
easier to write the query selector, I added the id attribute on the element as well.

https://github.com/mozilla/PollBot/pull/253