### PR TITLE
Update link to build instructions page

### DIFF
--- a/website/get-involved/index.html
+++ b/website/get-involved/index.html
@@ -93,7 +93,7 @@
               {{ _('<a href="https://hg.mozilla.org/comm-central/">comm-central</a> is the main Thunderbird repository.') }}
             </li>
             <li>
-              {{ _('Thunderbird also relies on the code from <a href="https://hg.mozilla.org/mozilla-central/">mozilla-central</a>. See the <a href="https://developer.thunderbird.net/the-basics/building-thunderbird">build instructions</a> for how to obtain all the code needed to build.') }}
+              {{ _('Thunderbird also relies on the code from <a href="https://hg.mozilla.org/mozilla-central/">mozilla-central</a>. See the <a href="https://developer.thunderbird.net/thunderbird-development/building-thunderbird">build instructions</a> for how to obtain all the code needed to build.') }}
             </li>
             <li>
               {{ _('You can search the code on <a href="https://searchfox.org/comm-central/source">SearchFox</a>.') }}


### PR DESCRIPTION
Seems https://developer.thunderbird.net/the-basics/building-thunderbird is 404 now, and the new url is
 https://developer.thunderbird.net/thunderbird-development/building-thunderbird