### PR TITLE
Fix Slovak calendar in calendars.json

### DIFF
--- a/media/caldata/calendars.json
+++ b/media/caldata/calendars.json
@@ -399,7 +399,7 @@
   {
     "country":"Slovakia",
     "filename":"SlovakHolidays.ics",
-    "datespan":"2009-2020",
+    "datespan":"2009-2025",
     "authors":"Branislav Rozbora"
   },
   {


### PR DESCRIPTION
Fix Slovak calendar in calendars.json (change end date from 2020 to 2025). ICS file was updated with holidays up to year 2025 in #101, but calendar.json was not updated. Because of that, webpage with calendar list still says "2009-2020". 

Fixes #190