### PR TITLE
Enable Canadian English (en-CA) locale

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -4,7 +4,7 @@
 PROD_LANGUAGES = (
     'ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg',
     'bn', 'br', 'bs', 'ca', 'cak', 'cs',
-    'cy', 'da', 'de', 'dsb', 'el', 'en-GB', 'en-US',
+    'cy', 'da', 'de', 'dsb', 'el', 'en-CA', 'en-GB', 'en-US',
     'en-ZA', 'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'et',
     'eu', 'fa', 'ff', 'fi', 'fr', 'fy-NL', 'ga-IE', 'gd',
     'gl', 'gn', 'gu-IN', 'he', 'hi-IN', 'hr', 'hsb',


### PR DESCRIPTION
Thunderbird 78 is shipping with the Canadian English locale, and the [website is also localized](https://pontoon.mozilla.org/en-CA/thunderbirdnet/). Please enable the en-CA locale. Thanks!