### PR TITLE
Removed holidays calendars with end date before 2020 from JSON file

### DIFF
--- a/media/caldata/calendars.json
+++ b/media/caldata/calendars.json
@@ -6,46 +6,16 @@
     "authors":"Imad Tbahriti"
   },
   {
-    "country":"Argentina",
-    "filename":"ArgentinaHolidays.ics",
-    "datespan":"2011-2016",
-    "authors":"Hernan Belloni, Gaudi"
-  },
-  {
-    "country":"Australia",
-    "filename":"AustraliaHolidays.ics",
-    "datespan":"2013",
-    "authors":"Jason Stirling"
-  },
-  {
     "country":"Austria",
     "filename":"AustrianHolidays.ics",
     "datespan":"2010-2025",
     "authors":"boe"
   },
   {
-    "country":"Basque",
-    "filename":"BasqueHolidays.ics",
-    "datespan":"2010-2012",
-    "authors":"Ander Elortondo"
-  },
-  {
     "country":"Belgium",
     "filename":"BelgianHolidays.ics",
     "datespan":"2011-2022",
     "authors":"Hubertus Verdonck"
-  },
-  {
-    "country":"Belgium (Dutch)",
-    "filename":"BelgianDutchHolidays.ics",
-    "datespan":"2007-2015",
-    "authors":"Peter Tonoli"
-  },
-  {
-    "country":"Belgium (French)",
-    "filename":"BelgianFrenchHolidays.ics",
-    "datespan":"2007-2015",
-    "authors":"Olivier Bosschem"
   },
   {
     "country":"Bolivia",
@@ -72,32 +42,6 @@
     "authors":"Sigurd Schmidt"
   },
   {
-    "country":"Canada / Quebec",
-    "filename":"CanadaQuebecHolidays.ics",
-    "datespan":"2013-2014",
-    "authors":"Fabian Rodriguez"
-  },
-  {
-    "country":"Chile",
-    "filename":"ChileHolidays.ics",
-    "datespan":"2011-2012",
-    "authors":"Emilio Sepulveda, Pablo Olmos de Aguilera Corradini"
-  },
-  {
-    "country":"China",
-    "filename":"ChinaHolidays.ics",
-    "datespan":"2013-2017",
-    "title":"Chinese Lunar calendar & Traditional Chinese holidays",
-    "authors":"Chen Wei"
-  },
-  {
-    "country":"China",
-    "filename":"ChinaPublicHolidays.ics",
-    "datespan":"2015",
-    "title":"China public holidays",
-    "authors":"Chen Wei"
-  },
-  {
     "country":"Colombia",
     "filename":"ColombianHolidays.ics",
     "datespan":"2000-2020",
@@ -120,24 +64,6 @@
     "filename":"CzechHolidays.ics",
     "datespan":"2007-2020",
     "authors":"Martin Matula, Matěj Cepl, Peter Habcak"
-  },
-  {
-    "country":"Denmark",
-    "filename":"DanishHolidays.ics",
-    "datespan":"2006-2015",
-    "authors":"Mads Boserup Lauritsen"
-  },
-  {
-    "country":"Dominican Republic (Spanish)",
-    "filename":"DominicanRepublicSpanish.ics",
-    "datespan":"2014",
-    "authors":"Grs Rodriguez"
-  },
-  {
-    "country":"Estonia",
-    "filename":"EstoniaHolidays.ics",
-    "datespan":"2014-2018",
-    "authors":"Merike Sell"
   },
   {
     "country":"Finland (Finnish)",
@@ -164,12 +90,6 @@
     "authors":"danfra"
   },
   {
-    "country":"Frisian",
-    "filename":"FrisianHolidays.ics",
-    "datespan":"2009-2015",
-    "authors":"Wim Benes"
-  },
-  {
     "country":"Germany",
     "filename":"GermanHolidays.ics",
     "datespan":"2010-2025",
@@ -182,21 +102,9 @@
     "authors":"Hans Kleiner"
   },
   {
-    "country":"Guyana",
-    "filename":"GuyanaHolidays.ics",
-    "datespan":"2013",
-    "authors":"RedSpider"
-  },
-  {
     "country":"Haiti",
     "filename":"HaitiHolidays.ics",
     "authors":" Sheila Laplanche"
-  },
-  {
-    "country":"Hong Kong",
-    "filename":"HongKongHolidays.ics",
-    "datespan":"2007-2013",
-    "authors":"Chun Chung Au"
   },
   {
     "country":"Hungary",
@@ -215,36 +123,6 @@
     "filename":"IrelandHolidays2014-2021.ics",
     "datespan":"2014-2021",
     "authors":"Tom Condon"
-  },
-  {
-    "country":"India",
-    "filename":"IndiaHolidays.ics",
-    "datespan":"2016",
-    "authors":"Seshu Parvataneni"
-  },
-  {
-    "country":"Indonesia (Bahasa)",
-    "filename":"IndonesianHolidays.ics",
-    "datespan":"2014",
-    "authors":"Gregorius Rivi"
-  },
-  {
-    "country":"Indonesia (English)",
-    "filename":"IndonesianHolidaysEnglish.ics",
-    "datespan":"2014",
-    "authors":"Achmad Junanto "
-  },
-  {
-    "country":"Iran (English)",
-    "filename":"IranHolidays_English.ics",
-    "datespan":"2007-2012",
-    "authors":"Mana Ghavifekr"
-  },
-  {
-    "country":"Iran (Persian)",
-    "filename":"IranHolidays_Persian.ics",
-    "datespan":"2012-2013",
-    "authors":"Mahdi"
   },
   {
     "country":"Italy",
@@ -271,34 +149,10 @@
     "authors":"Yuriy Gural"
   },
   {
-    "country":"Kenya",
-    "filename":"KenyaHolidays.ics",
-    "datespan":"2007-2015",
-    "authors":"Kevin Warnke"
-  },
-  {
-    "country":"Latvia",
-    "filename":"LatviaHolidays.ics",
-    "datespan":"2009-2014",
-    "authors":"dm"
-  },
-  {
-    "country":"Lithuanian",
-    "filename":"LithuanianHolidays.ics",
-    "datespan":"2012",
-    "authors":"Zai"
-  },
-  {
     "country": "Liechtenstein",
     "filename":"LiechtensteinHolidays.ics",
     "datespan":"2010-2025",
     "authors":"boe"
-  },
-  {
-    "country":"Luxembourg",
-    "filename":"LuxembourgHolidays.ics",
-    "datespan":"2010-2013",
-    "authors":"Ondra Kotecky"
   },
   {
     "country":"Morocco",
@@ -318,17 +172,10 @@
     "authors":"Pander"
   },
   {
-    "country":"New Zealand",
-    "filename":"NewZealandHolidays.ics",
-    "datespan":"2010-2013",
-    "authors":"Pete Griffin"
-  },
-  {
     "country":"Nicaragua",
     "filename":"NicaraguaHolidays.ics",
     "datespan":"2015-2020",
     "authors":"phurtado1112"
-
   },
   {
     "country":"Norway",
@@ -343,18 +190,6 @@
     "authors":"Umar Toseef"
   },
   {
-    "country":"Peru",
-    "filename":"PeruHolidays.ics",
-    "datespan":"2008-2013",
-    "authors":"Fernando Bustamante G"
-  },
-  {
-    "country":"Philippines",
-    "filename":"PhilippinesHolidays.ics",
-    "datespan":"2014",
-    "authors":"Victor"
-  },
-  {
     "country":"Poland",
     "filename":"PolishHolidays.ics",
     "datespan":"2009-2020",
@@ -367,28 +202,10 @@
     "authors":"Nuno Rua"
   },
   {
-    "country":"Queensland",
-    "filename":"QueenslandHolidays.ics",
-    "datespan":"2010-2014",
-    "authors":"Alan Kingsley"
-  },
-  {
     "country":"Russia",
     "filename":"RussiaHolidays.ics",
     "datespan":"2010-2020",
     "authors":"Alexander L. Slovesnik"
-  },
-  {
-    "country":"Romania",
-    "filename":"RomaniaHolidays.ics",
-    "datespan":"2016",
-    "authors":"Budai E. Bogdan"
-  },
-  {
-    "country":"Singapore",
-    "filename":"SingaporeHolidays.ics",
-    "datespan":"2014",
-    "authors":"Sunny"
   },
   {
     "country":"Slovenia",
@@ -415,18 +232,6 @@
     "authors":"Marcus Yoo"
   },
   {
-    "country":"Spain",
-    "filename":"SpanishHolidays.ics",
-    "datespan":"2007-2018",
-    "authors":"Ricardo Palomares"
-  },
-  {
-    "country":"Sri Lanka",
-    "filename":"SriLankaHolidays.ics",
-    "datespan":"2012-2014",
-    "authors":"Rukshan Abeyratne"
-  },
-  {
     "country":"Sweden",
     "filename":"SwedishHolidays.ics",
     "datespan":"2000-2020",
@@ -439,28 +244,10 @@
     "authors":"boe"
   },
   {
-    "country":"Taiwan",
-    "filename":"TaiwanHolidays.ics",
-    "datespan":"2011-2013",
-    "authors":"brli, Irvin, Pin-Guang Chen"
-  },
-  {
-    "country":"Thailand",
-    "filename":"ThaiHolidays.ics",
-    "datespan":"2012-2014",
-    "authors":"Hans Henderson"
-  },
-  {
     "country":"Trinidad and Tobago",
     "filename":"TrinidadTobagoHolidays.ics",
     "datespan":"2015-2025",
     "authors":"Joe"
-  },
-  {
-    "country":"Turkey",
-    "filename":"TurkeyHolidays.ics",
-    "datespan":"2011-2012",
-    "authors":"Berker Peksag, Jan Bambach"
   },
   {
     "country":"UK",
@@ -485,11 +272,5 @@
     "filename":"USHolidays.ics",
     "datespan":"2000-2020",
     "authors":"Marcus Yoo, Rob Craver"
-  },
-  {
-    "country":"Vietnam",
-    "filename":"VietnamHolidays.ics",
-    "datespan":"2009-2013",
-    "authors":"Tri Luu"
   }
 ]


### PR DESCRIPTION
I kept the calendar files as it had been done in the past.

(also see https://bugzilla.mozilla.org/show_bug.cgi?id=1427353)