### PR TITLE
Updating sizing of heading image for Safari Only

### DIFF
--- a/assets/less/base/sizing.less
+++ b/assets/less/base/sizing.less
@@ -35,10 +35,9 @@ each(@min-heights, #(@k, @v) {
 });
 
 @media screen and (-webkit-min-device-pixel-ratio:0) {
-	.platform-img {
-		width: 100%;
-		height: 100%;
-	}
+  .platform-img {
+     height: 100%;
+  }
 }
 
 each(@breakpoints, #(@k, @v) {

--- a/assets/less/base/sizing.less
+++ b/assets/less/base/sizing.less
@@ -34,6 +34,13 @@ each(@min-heights, #(@k, @v) {
   }
 });
 
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+	.platform-img {
+		width: 100%;
+		height: 100%;
+	}
+}
+
 each(@breakpoints, #(@k, @v) {
   @media (min-width: @k) {
     each(@widths, #(@i, @r) {


### PR DESCRIPTION
Updating css rule to the hero image doesn't look squashed on Safari for Mac OSX

[Screenshot of the issue on Safari](https://i.postimg.cc/vDFxVCVn/Screenshot-2021-04-05-at-18-39-14.png)