### PR TITLE
Fix mixed-up group links for enterprise and e2ee in get-involved

### DIFF
--- a/website/get-involved/index.html
+++ b/website/get-involved/index.html
@@ -98,10 +98,10 @@
               {{ _('<a href="https://thunderbird.topicbox.com/groups/developers">Developer List</a> - For technical discussion about Thunderbird development.') }}
             </li>
             <li>
-              {{ _('<a href="https://thunderbird.topicbox.com/groups/e2ee">Enterprise List</a> - For ADMINISTRATORS to discuss large scale deployment and configuration of Thunderbird.') }}
+              {{ _('<a href="https://thunderbird.topicbox.com/groups/enterprise">Enterprise List</a> - For ADMINISTRATORS to discuss large scale deployment and configuration of Thunderbird.') }}
             </li>
             <li>
-              {{ _('<a href="https://thunderbird.topicbox.com/groups/enterprise">E2EE List</a> - End-to-end Encryption using OpenPGP, OTR, and S/MIME.') }}
+              {{ _('<a href="https://thunderbird.topicbox.com/groups/e2ee">E2EE List</a> - End-to-end Encryption using OpenPGP, OTR, and S/MIME.') }}
             </li>
             <li>{{ _('<a href="https://thunderbird.topicbox.com/groups/planning">Planning List</a> - Discuss plans, strategy, policy, governance; improvements, meta issues; promote open standards; status, announcements; organize work to move Thunderbird forward!') }}
             </li>


### PR DESCRIPTION
Pinging @Sancus for review because it won't let me set a reviewer on the right where it says "Reviewers"