### PR TITLE
Update the donation host to the correct one

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -125,7 +125,7 @@ ENUS_ONLY = [
 ]
 
 DONATE_LINK = (
-    'https://donate.mozilla.org/thunderbird/'
+    'https://give.thunderbird.net/'
     '?utm_source={source}&utm_medium=referral&utm_content={content}'
 )
 


### PR DESCRIPTION
This was still set to the Mozilla Foundation donations website.

Closes #254 