### PR TITLE
Fix broken responsive behaviour of logos (#238)

### DIFF
--- a/website/_includes/base-resp.html
+++ b/website/_includes/base-resp.html
@@ -17,9 +17,8 @@
     <section class="flex justify-between items-center p-6 flex-wrap">
       {% block site_header_logo %}
         <h2 class="mt-0 mb-0">
-          <a href="{{ url('thunderbird.index') }}" class="block w-48 md:w-16 lg:w-56" title="{{ _('Thunderbird') }}" alt="{{ _('Thunderbird Vector Wordmark') }}">
-            <i class="block md:hidden lg:block">{{ svg('logo-wordmark-white') }}</i>
-            <i class="hidden md:block lg:hidden">{{ svg('logo') }}</i>
+          <a href="{{ url('thunderbird.index') }}" class="block w-48 lg:w-56" title="{{ _('Thunderbird') }}" alt="{{ _('Thunderbird Vector Wordmark') }}">
+            <i class="block">{{ svg('logo-wordmark-white') }}</i>
           </a>
         </h2>
       {% endblock %}


### PR DESCRIPTION
The issue is that the `logo-wordmark-white.svg` is embedded twice on the page (once in the header, once in the footer). The gradients that are defined in the SVG (`id="linearGradient-1"` and so on...) are then also defined twice. For this breakpoint the SVG in the footer referenced the gradients that were defined in the (now hidden) SVG in the header. Not hiding this logo fixes the issue:

![footer](https://user-images.githubusercontent.com/2980983/128760407-0a7ebca6-b1a9-4701-9d7a-c600123accfe.png)

Additionally this also fixed the broken header logo for this breakpoint, which is caused by the SVG having an inline width and height, which doesn't get reset by CSS (via `svg { width: 100%; height: auto; }` for example):

![header](https://user-images.githubusercontent.com/2980983/128760523-226be21c-ee29-4f61-bd77-7588ff4f2ada.png)
