### PR TITLE
Change daily download button to red, to match daily logo

### DIFF
--- a/assets/less/base/backgrounds.less
+++ b/assets/less/base/backgrounds.less
@@ -75,11 +75,11 @@ each(@background-size, #(@k, @v) {
 }
 
 .bg-daily-button {
-  background: #2A2A2E;
-  background: -moz-linear-gradient(-45deg, #737373 0%, #2A2A2E 100%);
-  background: -webkit-linear-gradient(-45deg, #737373 0%, #2A2A2E 100%);
-  background: linear-gradient(135deg, #737373 0%, #2A2A2E 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#737373', endColorstr='#2A2A2E', GradientType=1);
+  background: #890019;
+  background: -moz-linear-gradient(-45deg, #EB002D 0%, #890019 100%);
+  background: -webkit-linear-gradient(-45deg, #EB002D 0%, #890019 100%);
+  background: linear-gradient(135deg, #EB002D 0%, #890019 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#EB002D', endColorstr='#890019', GradientType=1);
 }
 
 .bg-body {


### PR DESCRIPTION
The beta download button matches the color of the beta logo. This pull request changes the color for the daily download button to match the daily logo, instead of being black:

![grafik](https://user-images.githubusercontent.com/5830621/131620990-ebb2afd1-9b98-4cc7-8c3a-a27d5bdc120f.png)
