### PR TITLE
Use matrix.to links to link to matrix channels

### DIFF
--- a/website/contact/index.html
+++ b/website/contact/index.html
@@ -44,10 +44,10 @@
 
       <article class="flex flex-col p-4 flex-1 lg:max-w-sm mb-10 lg:mb-0 bg-white rounded shadow-lg">
         <h4 class="mt-0 mb-4 uppercase text-blue font-md">
-          {{ _('<a href="https://chat.mozilla.org/#/room/#thunderbird:mozilla.org" class="header-link">Live Chat on Matrix</a>') }}
+          {{ _('<a href="https://matrix.to/#/#thunderbird:mozilla.org?web-instance%5Belement.io%5D=chat.mozilla.org" class="header-link">Live Chat on Matrix</a>') }}
         </h4>
         <p class="mt-0 mb-6 flex-1 p-links-blue">
-          {{ _('You can chat with other users and members of the Thunderbird team on the <a href="https://chat.mozilla.org/#/room/#thunderbird:mozilla.org">#thunderbird channel on Mozilla’s Matrix chat server</a>. You can log onto Matrix by <a href="https://wiki.mozilla.org/Matrix">following instructions on the wiki</a>. Matrix support in Thunderbird Chat is coming soon!') }}
+          {{ _('You can chat with other users and members of the Thunderbird team on the <a href="https://matrix.to/#/#thunderbird:mozilla.org?web-instance%5Belement.io%5D=chat.mozilla.org">#thunderbird channel on Mozilla’s Matrix chat server</a>. You can log onto Matrix by <a href="https://wiki.mozilla.org/Matrix">following instructions on the wiki</a>. Matrix support in Thunderbird Chat is coming soon!') }}
         </p>
       </article>
     </section>

--- a/website/get-involved/index.html
+++ b/website/get-involved/index.html
@@ -121,19 +121,19 @@
           </p>
           <ul class="font-md tracking-wider leading-loose mb-6 p-links-blue">
             <li>
-              {{ _('<a href="https://chat.mozilla.org/#/room/#thunderbird:mozilla.org">#thunderbird</a> - For general questions and support.') }}
+              {{ _('<a href="https://matrix.to/#/#thunderbird:mozilla.org?web-instance%5Belement.io%5D=chat.mozilla.org">#thunderbird</a> - For general questions and support.') }}
             </li>
             <li>
-              {{ _('<a href="https://chat.mozilla.org/#/room/#maildev:mozilla.org">#maildev</a> - For hacking on Thunderbird.') }}
+              {{ _('<a href="https://matrix.to/#/#maildev:mozilla.org?web-instance%5Belement.io%5D=chat.mozilla.org">#maildev</a> - For hacking on Thunderbird.') }}
             </li>
             <li>
-              {{ _('<a href="https://chat.mozilla.org/#/room/#tb-addon-developers:mozilla.org">#tb-addon-developers</a> - For questions and discussion about Thunderbird add-on development.') }}
+              {{ _('<a href="https://matrix.to/#/#tb-addon-developers:mozilla.org?web-instance%5Belement.io%5D=chat.mozilla.org">#tb-addon-developers</a> - For questions and discussion about Thunderbird add-on development.') }}
             </li>
             <li>
-              {{ _('<a href="https://chat.mozilla.org/#/room/#openpgp:mozilla.org">#openpgp</a> - For OpenPGP discussion.') }}
+              {{ _('<a href="https://matrix.to/#/#openpgp:mozilla.org?web-instance%5Belement.io%5D=chat.mozilla.org">#openpgp</a> - For OpenPGP discussion.') }}
             </li>
             <li>
-              {{ _('<a href="https://chat.mozilla.org/#/room/#tb-support-crew:mozilla.org">#tb-support-crew</a> - For management of Thunderbird support.') }}
+              {{ _('<a href="https://matrix.to/#/#tb-support-crew:mozilla.org?web-instance%5Belement.io%5D=chat.mozilla.org">#tb-support-crew</a> - For management of Thunderbird support.') }}
             </li>
         </article>
       </aside>


### PR DESCRIPTION
When Mozilla first started using Matrix there was no good way for matrix.to to guide people to chat.mozilla.org, which is why usually chat.mozilla.org deep links were used. However, matrix.to now allows specifying the element web client instance that should be advertised. Using matrix.to links has the benefit that it can offer direct links for opening the room in other clients, or instructions, or on Android they are usually the main link handler Matrix apps will register. Thus using matrix.to links makes it easier for users that already are in the Matrix ecosystem to join the rooms, while still offering a simple path to the element web instance.