### PR TITLE
Bug 1695596 - Set up redirect URL for latest beta notes

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -231,8 +231,10 @@ class Site(object):
         # Build htaccess files for sysreq and release notes redirects.
         sysreq_path = os.path.join(self.renderpath, 'system-requirements')
         notes_path = os.path.join(self.renderpath, 'notes')
+        beta_notes_path = os.path.join(self.renderpath, 'notes', 'beta')
         write_htaccess(sysreq_path, settings.CANONICAL_URL + helper.thunderbird_url('system-requirements'))
         write_htaccess(notes_path, settings.CANONICAL_URL + helper.thunderbird_url('releasenotes'))
+        write_htaccess(beta_notes_path, settings.CANONICAL_URL + helper.thunderbird_url('releasenotes', channel="beta"))
 
     def build_assets(self):
         """Build assets, that is, bundle and compile the LESS and JS files in `settings.ASSETS`."""


### PR DESCRIPTION
Bug 1695596 modifies the buttons in the "Update Failed" prompt to make use of "thunderbird.net/notes/" and "thunderbird.net/notes/beta/" URLs to get the latest release notes for whichever channel Thunderbird is using.