### PR TITLE
Set known esr major release versions eplicitly to avoid mishaps.

### DIFF
--- a/product_details.py
+++ b/product_details.py
@@ -143,12 +143,7 @@ class ThunderbirdDetails():
         return self.platform_labels.items()
 
     def list_releases(self, channel='beta'):
-        version_name = self.version_map.get(channel, 'LATEST_THUNDERBIRD_DEVEL_VERSION')
-        esr_major_versions = (
-            list(range(10, 59, 7))
-            + [60, 68]
-            + list(range(78, int(self.current_versions[version_name].split('.')[0]) + 1, 13))
-        )
+        esr_major_versions = (10, 17, 24, 31, 38, 45, 52, 60, 68, 78, 91, 102)
         releases = {}
         for release in self.major_releases:
             major_version = float(re.findall(r'^\d+\.\d+', release)[0])


### PR DESCRIPTION
Fixes #325.

The 102.x release notes were being thrown off by "esr_major_versions" not including
102. Rather than try to define a pattern for the esr major versions, adopt the method
used by the "mozilla-version" Python package, and just explicitly liat them out.
This does mean adding to the list every year, but there's no chance of getting
thrown off when the interval changes again.