### PR TITLE
Outdated page

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -166,3 +166,5 @@ WEBSITE_JS = {
 START_CSS = {
     'start-style': ['less.old/sandstone/fonts.less', 'less.old/thunderbird/start.less']
 }
+
+LAST_SAFE_VERSION = 91

--- a/start-page/_new-base-resp.html
+++ b/start-page/_new-base-resp.html
@@ -10,7 +10,7 @@
     <title>{% filter striptags|e %}{% block title %}{% endblock %}{% endfilter %}</title>
     {{ l10n_css() }}
     <link href="/media/css/new-start-style.css" rel="stylesheet" type="text/css" />
-    {% block additional_styles %}{% endblock %}
+    {% block additional_head %}{% endblock %}
   </head>
   <body class="start-bg">
     <main>

--- a/start-page/_new-base-resp.html
+++ b/start-page/_new-base-resp.html
@@ -10,6 +10,7 @@
     <title>{% filter striptags|e %}{% block title %}{% endblock %}{% endfilter %}</title>
     {{ l10n_css() }}
     <link href="/media/css/new-start-style.css" rel="stylesheet" type="text/css" />
+    {% block additional_styles %}{% endblock %}
   </head>
   <body class="start-bg">
     <main>

--- a/start-page/outdated/index.html
+++ b/start-page/outdated/index.html
@@ -1,81 +1,96 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
- # License, v. 2.0. If a copy of the MPL was not distributed with this
- # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-<!DOCTYPE html>
-<html lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}">
-  <head>
-    <meta charset="utf-8">
-    <meta name="robots" content="noindex">
-    <title>{% block title %}{{ _('Your Thunderbird is Not Up-to-Date!') }}{% endblock %}</title>
-    {{ l10n_css() }}
-    <!-- Fontawesome added below -->
-    <link href="/media/css/fontawesome-all.css" rel="stylesheet">
-    <!--<script defer src="/media/js/fontawesome-all.js"></script>-->
-    <style>
-      body {
-        background-color: #D46A6A;
-        text-align: center;
-      }
-    </style>
-  </head>
-  <body>
-    <main>
-    <h1><b><i class="fas fa-exclamation-triangle fa-3x" style="color:#0060df"></i> {{ self.title() }}</b></h1>
+{% extends "_new-base-resp.html" %}
+
+{% block channel %}release{% endblock %}
+{% block title %}{{ _('Your Thunderbird is Not Up-to-Date!') }}{% endblock %}
+
+{% block additional_head %}
+<style>
+  body {
+    background-image: none;
+    background-color: #D46A6A;
+    color: #000;
+    text-align: center;
+  }
+
+  .main-content {
+    display: block;
+  }
+
+  .outdated-warning-icon {
+    display: inline-block;
+    position: relative;
+    top: 8px;
+    width: 32px;
+    height: 32px;
+    color: #0060df;
+  }
+</style>
+{% endblock %}
+
+{% block main %}
+<div class="main-content">
+  <section id="outdated-message">
+    <h1><b><span class="outdated-warning-icon">{{ svg('warning') }}</span> {{ self.title() }}</b></h1>
     <h2 id="duration">{{ _('Your version, $vers, is no longer a supported Thunderbird release and hasn’t received updates in at least $mon months.') }}</h2>
-    <p class="fa-lg">{{ _('We <b>strongly recommend</b> downloading the <a href="%(download_url)s">latest stable version of Thunderbird</a>.')|format(download_url='https://thunderbird.net') }}</p>
-    <p class="fa-lg">{{ _('For more information, please check this <a href="%(support_url)s">support article</a> on upgrading old versions.')|format(support_url='https://support.mozilla.org/en-US/products/thunderbird') }}</p>
-    </main>
-  </body>
+    <p>{{ _('We <b>strongly recommend</b> downloading the
+      <a href="%(download_url)s">latest stable version of Thunderbird</a>.')|format(download_url='https://thunderbird.net') }}
+    </p>
+    <p>{{ _('For more information, please check this
+      <a href="%(support_url)s">support article</a> on upgrading old versions.')|format(support_url='https://support.mozilla.org/en-US/products/thunderbird') }}
+    </p>
+  </section>
+</div>
 <script>
+  // Date of last security release for each major version.
+  version_dates = {{ get_outdated_versions() }}
 
-// Date of last security release for each major version.
-version_dates = {
-  24: new Date(2014, 8, 2),
-  31: new Date(2015, 6, 17),
-  38: new Date(2016, 4, 4),
-  45: new Date(2017, 2, 7),
-  52: new Date(2018, 6, 10),
-  60: new Date(2019, 10, 5)
-}
+  function getVersionDate(version) {
+    return new Date(version_dates[version]);
+  }
 
-function monthDiff(dateFrom, dateTo) {
- return dateTo.getMonth() - dateFrom.getMonth() +
-   (12 * (dateTo.getFullYear() - dateFrom.getFullYear()))
-}
+  function monthDiff(dateFrom, dateTo) {
+    return dateTo.getMonth() - dateFrom.getMonth() +
+      (12 * (dateTo.getFullYear() - dateFrom.getFullYear()))
+  }
 
-function get_browser() {
-    var ua=navigator.userAgent,tem,M=ua.match(/(firefox|thunderbird(?=\/))\/?\s*(\d+)/i) || [];
-    M=M[2]? [M[1], M[2]]: [navigator.appName, navigator.appVersion, '-?'];
-    if((tem=ua.match(/version\/(\d+)/i))!=null) {M.splice(1,1,tem[1]);}
+  function get_browser() {
+    var ua = navigator.userAgent, tem, M = ua.match(/(firefox|thunderbird(?=\/))\/?\s*(\d+)/i) || [];
+    M = M[2] ? [M[1], M[2]] : [navigator.appName, navigator.appVersion, '-?'];
+    if ((tem = ua.match(/version\/(\d+)/i)) != null) {
+      M.splice(1, 1, tem[1]);
+    }
     return {
       name: M[0],
       version: M[1]
     };
- }
+  }
 
-// Clamp the version number to the closest among version_dates.
-function get_version(vers) {
-  // This instead of Object.keys() for compatibility with old versions.
-  var versions = [], i = 0;
-  for (versions[i++] in version_dates) {}
+  // Clamp the version number to the closest among version_dates.
+  function get_version(vers) {
+    // This instead of Object.keys() for compatibility with old versions.
+    var versions = [], i = 0;
+    for (versions[i++] in version_dates) {
+    }
 
-  var closest = versions.reduce(function(prev, curr) {
-    return (Math.abs(curr - vers) < Math.abs(prev - vers) ? curr : prev);
-  });
+    var closest = versions.reduce(function (prev, curr) {
+      return (Math.abs(curr - vers) < Math.abs(prev - vers) ? curr : prev);
+    });
 
-  return closest;
-}
+    return closest;
+  }
 
-// browser.name = 'Thunderbird', browser.version = '60'
-var browser=get_browser();
-clamped_version = get_version(browser.version);
+  // browser.name = 'Thunderbird', browser.version = '60'
+  var browser = get_browser();
+  clamped_version = get_version(browser.version);
 
-var rel_date = version_dates[clamped_version] || new Date();
-var num_months = monthDiff(rel_date, new Date()) || 12;
+  var rel_date = getVersionDate(clamped_version) || new Date();
+  var num_months = monthDiff(rel_date, new Date()) || 12;
 
-duration = document.getElementById('duration').innerHTML;
-document.getElementById('duration').innerHTML = duration.replace('$mon', num_months).replace('$vers', browser.version);
-
+  duration = document.getElementById('duration').innerHTML;
+  document.getElementById('duration').innerHTML = duration.replace('$mon', num_months).replace('$vers', browser.version);
 </script>
-</html>
+{% endblock %}


### PR DESCRIPTION
Resolves #170 

This updates the page to be on the newest start template, and grabs the dates/versions programmatically based off the new `settings.LAST_SAFE_VERSION` variable. If we could grab the last safe version from product details that would be rad, but this should make it quite simple to update. 

We're still missing the support article, but I can also just make the line about the support article more generic. 

Screenshots:
Thunderbird v10.0.1
![v10 0 1](https://user-images.githubusercontent.com/97147377/205998227-4f152923-83fa-497e-b47d-c1473e9c5c91.png)
Thunderbird v31.8.0
![v31 8 0](https://user-images.githubusercontent.com/97147377/205998286-d0d6d37e-7e75-41b0-91dd-b58c009e5c6b.png)
Thunderbird v78.9.1
![v78 9 1](https://user-images.githubusercontent.com/97147377/205998327-38a3bdc4-0cc1-455d-ae07-743e109742f2.png)

During testing I noticed we use Let's Encrypt which has deprecated [an older CA](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/) a while ago. On an older system that hasn't been updated with the new root certificate this will cause a white screen (if it's in the message body section) or an certificate error page. Probably not an issue, because it's unlikely that someone would be this outdated (except for my virtual machine), but something to keep in mind.
![v10 0 1-cert](https://user-images.githubusercontent.com/97147377/205999679-87ac3afd-a9d1-485d-832b-5d0dc6a04207.png)
