### PR TITLE
Allow localized beta downloads

### DIFF
--- a/product_details.py
+++ b/product_details.py
@@ -20,6 +20,28 @@ def load_json(path):
     with open(path, 'r') as f:
         return json.load(f)
 
+def load_all_builds(path):
+    """ Loads the all_builds data, and mixes in the latest beta information with all release locales. """
+    all_builds = load_json(path)
+
+    if 'all' not in all_builds:
+        return all_builds
+
+    all_data = {}
+
+    # Filter just the beta builds
+    for build, info in all_builds.get('all').items():
+        if 'b' in build:
+            all_data.update({build: info})
+
+    for locale, build in all_builds.items():
+        # Already has beta information
+        if locale == 'en-US' or locale == 'all':
+            continue
+        # Merge the beta build information
+        all_builds[locale].update(all_data)
+
+    return all_builds
 
 class ThunderbirdDetails():
     """ Loads Thunderbird versioning information from product details JSON files."""
@@ -37,7 +59,7 @@ class ThunderbirdDetails():
 
     current_versions = load_json('thunderbird_versions.json')
 
-    all_builds = load_json('thunderbird_primary_builds.json')
+    all_builds = load_all_builds('thunderbird_primary_builds.json')
 
     major_releases = load_json('thunderbird_history_major_releases.json')
 

--- a/product_details.py
+++ b/product_details.py
@@ -20,28 +20,31 @@ def load_json(path):
     with open(path, 'r') as f:
         return json.load(f)
 
+
 def load_all_builds(path):
     """ Loads the all_builds data, and mixes in the latest beta information with all release locales. """
     all_builds = load_json(path)
 
-    if 'all' not in all_builds:
+    # We heavily rely on en-US, but if somehow that's no longer a locale, at least don't crash here.
+    if 'en-US' not in all_builds:
         return all_builds
 
     all_data = {}
 
     # Filter just the beta builds
-    for build, info in all_builds.get('all').items():
+    for build, info in all_builds.get('en-US').items():
         if 'b' in build:
             all_data.update({build: info})
 
     for locale, build in all_builds.items():
         # Already has beta information
-        if locale == 'en-US' or locale == 'all':
+        if locale == 'en-US':
             continue
         # Merge the beta build information
         all_builds[locale].update(all_data)
 
     return all_builds
+
 
 class ThunderbirdDetails():
     """ Loads Thunderbird versioning information from product details JSON files."""


### PR DESCRIPTION
Resolves #350 

I'm using the `all` key here, which only has beta and daily information. But I can use en-US if that works better.  I'm filtering the `all` key for beta builds only. So daily will still be en-US.

Tested it out locally with all the languages that have localized releases, and works great. (And now I have about 65 builds in my downloads folder.)

