### PR TITLE
FRU: replace all donation links with fru

### DIFF
--- a/assets/js/common/ab-testing.js
+++ b/assets/js/common/ab-testing.js
@@ -93,8 +93,21 @@ if (typeof Mozilla === 'undefined') {
      */
     ABTest.Donate = function(event) {
         if (ABTest.IsInFundraiseUpBucket()) {
+            const element = event.target;
+            // If we somehow don't have an element, we can exit and still start any redirects.
+            if (!element) {
+                return;
+            }
+
             event.preventDefault();
-            window.location = "?form=support";
+
+            // Falsey fallback check to transform '' => null
+            const utmContent = element.getAttribute('data-donate-content') || null;
+            const utmSource = element.getAttribute('data-donate-source') || 'thunderbird.net';
+            const utmMedium = element.getAttribute('data-donate-medium') || 'referral';
+            const utmCampaign = element.getAttribute('data-donate-campaign') || null;
+
+            window.Mozilla.Donation.Donate(utmContent, utmSource, utmMedium, utmCampaign);
         }
     }
 

--- a/assets/js/common/ab-testing.js
+++ b/assets/js/common/ab-testing.js
@@ -87,9 +87,33 @@ if (typeof Mozilla === 'undefined') {
         }
     }
 
-    // Note: Intentionally uncommented for testing.
-    // Pick one!
-    //ABTest.Choose();
+    /**
+     * If FRU prevent the link redirect, and call up the donation form.
+     * @param event : Event
+     */
+    ABTest.Donate = function(event) {
+        if (ABTest.IsInFundraiseUpBucket()) {
+            event.preventDefault();
+            window.location = "?form=support";
+        }
+    }
+
+    /**
+     * Any required initializations for our ABTest should go here
+     * Called after ABTest is added to the Mozilla namespace.
+     */
+    ABTest.Init = function() {
+        // Note: Intentionally uncommented for testing.
+        // Pick one!
+        //ABTest.Choose();
+
+        const donate_buttons = document.querySelectorAll('[data-donate-btn]');
+        for (const donate_button of donate_buttons) {
+            donate_button.addEventListener('click', ABTest.Donate);
+        }
+    }
 
     window.Mozilla.ABTest = ABTest;
+
+    ABTest.Init();
 })();

--- a/assets/js/common/ab-testing.js
+++ b/assets/js/common/ab-testing.js
@@ -47,7 +47,7 @@ if (typeof Mozilla === 'undefined') {
      * @private
      */
     ABTest._FundraiseUpDownload = function(download_url) {
-        window.Mozilla.Donation.DisplayAmountForm(download_url);
+        window.Mozilla.Donation.DisplayDownloadForm(download_url);
     }
 
     /**

--- a/assets/js/common/donations.js
+++ b/assets/js/common/donations.js
@@ -20,6 +20,30 @@ if (typeof Mozilla === 'undefined') {
     Donation.CurrentDownloadLink = null;
 
     /**
+     * Display FRUs donation form
+     * @param utmContent {?string}
+     * @param utmSource {?string}
+     * @param utmMedium {?string}
+     * @param utmCampaign {?string}
+     */
+    Donation.Donate = function(utmContent = null, utmSource = 'thunderbird.net', utmMedium = 'referral', utmCampaign = null) {
+        let params = {
+            'form': 'support',
+            'utm_content': utmContent,
+            'utm_source': utmSource,
+            'utm_medium': utmMedium,
+            'utm_campaign': utmCampaign
+        };
+        // Filter nulls from the object (this mutates)
+        Object.keys(params).forEach((k) => params[k] == null && delete params[k]);
+
+        params = new URLSearchParams(params);
+
+        // Display the FRU form
+        location.href = `?${params.toString()}`;
+    }
+
+    /**
      * Close the donation form
      * This will clear any currently set download link.
      */
@@ -104,7 +128,7 @@ if (typeof Mozilla === 'undefined') {
                 // Timeout is here to prevent url collisions with fundraiseup form.
                 window.setTimeout(function() {
                     location.href = download_link;
-                },1000);
+                }, 1000);
             });
         }
     };

--- a/assets/js/common/donations.js
+++ b/assets/js/common/donations.js
@@ -8,6 +8,7 @@ if (typeof Mozilla === 'undefined') {
 
     var Donation = {};
     Donation.ANIMATION_DURATION = 250;
+    Donation.IsVisible = false;
 
     /**
      * Close the donation form
@@ -16,17 +17,19 @@ if (typeof Mozilla === 'undefined') {
         $('#amount-modal').fadeOut(Donation.ANIMATION_DURATION);
         $('#modal-overlay').fadeOut(Donation.ANIMATION_DURATION);
         $(document.body).removeClass('overflow-hidden');
+        Donation.IsVisible = false;
     }
 
     /**
-     * Display the donation modal for fundraise up
+     * Display the donation download modal for fundraise up
      * @param download_url - Link to the actual file download
      */
-    Donation.DisplayAmountForm = function(download_url) {
+    Donation.DisplayDownloadForm = function(download_url) {
         // Show the donation form.
         $('#amount-modal').fadeIn(Donation.ANIMATION_DURATION);
         $('#modal-overlay').fadeIn(Donation.ANIMATION_DURATION);
         $(document.body).addClass('overflow-hidden');
+        Donation.IsVisible = true;
 
         // Define cancel and close button on the donation form.
         $('#amount-cancel').click(function(e) {
@@ -72,6 +75,11 @@ if (typeof Mozilla === 'undefined') {
             const fundraiseUp = window.FundraiseUp;
             // Close our modal on open
             fundraiseUp.on('checkoutOpen', function() {
+                // Don't start the download if we didn't come from the donation download modal
+                if (!Donation.IsVisible) {
+                    return;
+                }
+
                 Donation.CloseForm();
 
                 // Timeout is here to prevent url collisions with fundraiseup form.

--- a/assets/js/common/donations.js
+++ b/assets/js/common/donations.js
@@ -8,16 +8,27 @@ if (typeof Mozilla === 'undefined') {
 
     var Donation = {};
     Donation.ANIMATION_DURATION = 250;
+    /**
+     * Is the download form visible?
+     * @type {boolean}
+     */
     Donation.IsVisible = false;
+    /**
+     * Stateful download link to be retrieved by the FRU on.checkoutOpen event
+     * @type {?string}
+     */
+    Donation.CurrentDownloadLink = null;
 
     /**
      * Close the donation form
+     * This will clear any currently set download link.
      */
     Donation.CloseForm = function() {
         $('#amount-modal').fadeOut(Donation.ANIMATION_DURATION);
         $('#modal-overlay').fadeOut(Donation.ANIMATION_DURATION);
         $(document.body).removeClass('overflow-hidden');
         Donation.IsVisible = false;
+        Donation.CurrentDownloadLink = null;
     }
 
     /**
@@ -30,6 +41,7 @@ if (typeof Mozilla === 'undefined') {
         $('#modal-overlay').fadeIn(Donation.ANIMATION_DURATION);
         $(document.body).addClass('overflow-hidden');
         Donation.IsVisible = true;
+        Donation.CurrentDownloadLink = download_url;
 
         // Define cancel and close button on the donation form.
         $('#amount-cancel').click(function(e) {
@@ -80,11 +92,18 @@ if (typeof Mozilla === 'undefined') {
                     return;
                 }
 
+                // Retrieve the current download link before we close the form (as that clears it)
+                const download_link = Donation.CurrentDownloadLink;
                 Donation.CloseForm();
+
+                // No download link? Exit.
+                if (!download_link) {
+                    return;
+                }
 
                 // Timeout is here to prevent url collisions with fundraiseup form.
                 window.setTimeout(function() {
-                    location.href = download_url;
+                    location.href = download_link;
                 },1000);
             });
         }

--- a/website/_includes/base-resp.html
+++ b/website/_includes/base-resp.html
@@ -24,7 +24,7 @@
       {% endblock %}
 
       {% block site_header_nav %}
-        <a href="{{ donate_url('header') }}" class="btn-donate md:hidden">
+        <a href="{{ donate_url('header') }}" class="btn-donate md:hidden" data-donate-btn>
           <span class="inline-block w-3 mr-1">{{ svg('heart') }}</span> {{_('Donate')}}
         </a>
         <nav id="nav-main" role="navigation" class="flex-grow md:flex-grow-0">
@@ -48,7 +48,7 @@
               <a href="{{ url('blog') }}" class="nav-link">{{_('Blog')}}</a>
             </li>
             <li class="hidden md:inline">
-              <a href="{{ donate_url('header') }}" class="btn-donate">
+              <a href="{{ donate_url('header') }}" class="btn-donate" data-donate-btn>
                 <span class="inline-block w-3 mr-1">{{ svg('heart') }}</span> {{_('Donate')}}
               </a>
             </li>

--- a/website/_includes/base-resp.html
+++ b/website/_includes/base-resp.html
@@ -24,7 +24,7 @@
       {% endblock %}
 
       {% block site_header_nav %}
-        <a href="{{ donate_url('header') }}" class="btn-donate md:hidden" data-donate-btn>
+        <a href="{{ donate_url('header') }}" class="btn-donate md:hidden" data-donate-btn data-donate-content="header">
           <span class="inline-block w-3 mr-1">{{ svg('heart') }}</span> {{_('Donate')}}
         </a>
         <nav id="nav-main" role="navigation" class="flex-grow md:flex-grow-0">
@@ -48,7 +48,7 @@
               <a href="{{ url('blog') }}" class="nav-link">{{_('Blog')}}</a>
             </li>
             <li class="hidden md:inline">
-              <a href="{{ donate_url('header') }}" class="btn-donate" data-donate-btn>
+              <a href="{{ donate_url('header') }}" class="btn-donate" data-donate-btn data-donate-content="header">
                 <span class="inline-block w-3 mr-1">{{ svg('heart') }}</span> {{_('Donate')}}
               </a>
             </li>

--- a/website/_includes/donate-mailing-list.html
+++ b/website/_includes/donate-mailing-list.html
@@ -13,7 +13,7 @@
     <p class="font-lg tracking-wider leading-loose mb-8 mt-0 flex-1">
       {{ _('Thunderbird is both free and freedom respecting, but we’re also completely funded by donations! Help us sustain the project and continue to improve.') }}
     </p>
-    <a href="{{ donate_url('home_page_body') }}" class="btn-donate self-start ml-0 mr-0 font-lg lg:font-base" data-donate-btn>
+    <a href="{{ donate_url('home_page_body') }}" class="btn-donate self-start ml-0 mr-0 font-lg lg:font-base" data-donate-btn data-donate-content="home_page_body">
       <span class="inline-block w-3 mr-1">{{ svg('heart') }}</span> {{_('Donate')}}
     </a>
   </aside>

--- a/website/_includes/donate-mailing-list.html
+++ b/website/_includes/donate-mailing-list.html
@@ -13,7 +13,7 @@
     <p class="font-lg tracking-wider leading-loose mb-8 mt-0 flex-1">
       {{ _('Thunderbird is both free and freedom respecting, but we’re also completely funded by donations! Help us sustain the project and continue to improve.') }}
     </p>
-    <a href="{{ donate_url('home_page_body') }}" class="btn-donate self-start ml-0 mr-0 font-lg lg:font-base">
+    <a href="{{ donate_url('home_page_body') }}" class="btn-donate self-start ml-0 mr-0 font-lg lg:font-base" data-donate-btn>
       <span class="inline-block w-3 mr-1">{{ svg('heart') }}</span> {{_('Donate')}}
     </a>
   </aside>

--- a/website/_includes/site-prefooter.html
+++ b/website/_includes/site-prefooter.html
@@ -17,7 +17,7 @@
           {{_('Join Us')}}
         </a>
         <p class="font-sm mt-0 text-blue font-semibold self-start">
-          <a href="{{ donate_url('pre_footer') }}" class="small-link text-blue" data-donate-btn>{{ _('Make a Donation') }}</a> &bull;
+          <a href="{{ donate_url('pre_footer') }}" class="small-link text-blue" data-donate-btn data-donate-content="pre_footer">{{ _('Make a Donation') }}</a> &bull;
           <a href="https://support.mozilla.org/products/thunderbird/"
             class="small-link text-blue">{{ _('Get Support') }}</a> &bull;
           <a href="https://bugzilla.mozilla.org/describecomponents.cgi?product=Thunderbird"

--- a/website/_includes/site-prefooter.html
+++ b/website/_includes/site-prefooter.html
@@ -17,7 +17,7 @@
           {{_('Join Us')}}
         </a>
         <p class="font-sm mt-0 text-blue font-semibold self-start">
-          <a href="{{ donate_url('pre_footer') }}" class="small-link text-blue">{{ _('Make a Donation') }}</a> &bull;
+          <a href="{{ donate_url('pre_footer') }}" class="small-link text-blue" data-donate-btn>{{ _('Make a Donation') }}</a> &bull;
           <a href="https://support.mozilla.org/products/thunderbird/"
             class="small-link text-blue">{{ _('Get Support') }}</a> &bull;
           <a href="https://bugzilla.mozilla.org/describecomponents.cgi?product=Thunderbird"

--- a/website/thunderbird/102.0/whatsnew/index.html
+++ b/website/thunderbird/102.0/whatsnew/index.html
@@ -19,7 +19,7 @@
         <p class="tracking-wide leading-normal m-0 text-center">
           {{ _('<strong>Thunderbird is completely funded by your donations.</strong> <br> Producing Thunderbird requires software engineers, designers, system administrators and server infrastructure. <strong>Help us keep Thunderbird alive!</strong>') }}
         </p>
-        <a href="{{ donate_url('cta', 'whats_new_page', 'thunderbird', 'whats_new_102') }}" class="btn-donate-lg mt-4">
+        <a href="{{ donate_url('cta', 'whats_new_page', 'thunderbird', 'whats_new_102') }}" class="btn-donate-lg mt-4" data-donate-btn>
           <span class="inline-block w-5 mr-1">{{ svg('heart') }}</span>
           {{ _('Donate') }}
         </a>

--- a/website/thunderbird/102.0/whatsnew/index.html
+++ b/website/thunderbird/102.0/whatsnew/index.html
@@ -19,7 +19,7 @@
         <p class="tracking-wide leading-normal m-0 text-center">
           {{ _('<strong>Thunderbird is completely funded by your donations.</strong> <br> Producing Thunderbird requires software engineers, designers, system administrators and server infrastructure. <strong>Help us keep Thunderbird alive!</strong>') }}
         </p>
-        <a href="{{ donate_url('cta', 'whats_new_page', 'thunderbird', 'whats_new_102') }}" class="btn-donate-lg mt-4" data-donate-btn>
+        <a href="{{ donate_url('cta', 'whats_new_page', 'thunderbird', 'whats_new_102') }}" class="btn-donate-lg mt-4" data-donate-btn data-donate-content="cta" data-donate-source="whats_new_page" data-donate-medium="thunderbird" data-donate-campaign="whats_new_102">
           <span class="inline-block w-5 mr-1">{{ svg('heart') }}</span>
           {{ _('Donate') }}
         </a>

--- a/website/thunderbird/91.0/whatsnew/index.html
+++ b/website/thunderbird/91.0/whatsnew/index.html
@@ -18,7 +18,7 @@
       </p>
 
       <div class="flex mb-20">
-        <a href="{{ donate_url('home_page_body') }}" class="btn-donate btn-donate-whatsnew font-lg">
+        <a href="{{ donate_url('home_page_body') }}" class="btn-donate btn-donate-whatsnew font-lg" data-donate-btn>
           <span class="inline-block w-4 mr-1">{{ svg('heart') }}</span> {{_('Donate')}}
         </a>
       </div>

--- a/website/thunderbird/91.0/whatsnew/index.html
+++ b/website/thunderbird/91.0/whatsnew/index.html
@@ -18,7 +18,7 @@
       </p>
 
       <div class="flex mb-20">
-        <a href="{{ donate_url('home_page_body') }}" class="btn-donate btn-donate-whatsnew font-lg" data-donate-btn>
+        <a href="{{ donate_url('home_page_body') }}" class="btn-donate btn-donate-whatsnew font-lg" data-donate-btn data-donate-content="home_page_body">
           <span class="inline-block w-4 mr-1">{{ svg('heart') }}</span> {{_('Donate')}}
         </a>
       </div>


### PR DESCRIPTION
Resolves #366 

Also fixes a bug introduced in https://github.com/thundernest/thunderbird-website/pull/356 (oops, my b) that seemingly broke the downloads for beta/daily.

This method does technically reload the page, but that's technically what the custom FRU button element does. So it's a little jarring on buttons further down the page.