### PR TITLE
Redirect the supporter to the Newsletter landing page if they selected "Subscribe to newsletter"

### DIFF
--- a/assets/js/common/donations.js
+++ b/assets/js/common/donations.js
@@ -33,6 +33,7 @@ if (typeof Mozilla === 'undefined') {
         const fundraiseUp = window.FundraiseUp;
 
         /**
+         * Event fires when the FRU checkout modal opens
          * @param details - See https://fundraiseup.com/docs/parameters/
          */
         fundraiseUp.on('checkoutOpen', function(details) {
@@ -50,6 +51,21 @@ if (typeof Mozilla === 'undefined') {
             window.setTimeout(function() {
                 window.open(download_link, '_self');
             }, 1000);
+        });
+        /**
+         * Event fires when the FRU conversion is completed successfully.
+         * @param details - See https://fundraiseup.com/docs/parameters/
+         */
+        fundraiseUp.on('donationComplete', function(details) {
+            if (!details || !details.supporter) {
+                return;
+            }
+
+            const hasSubscribedToNewsletter = details.supporter.mailingListSubscribed || false;
+
+            if (hasSubscribedToNewsletter) {
+                window.open(`/${window.siteLocale}/newsletter`, '_blank');
+            }
         });
     }
 

--- a/website/_includes/bedrock/base-resp.html
+++ b/website/_includes/bedrock/base-resp.html
@@ -45,6 +45,9 @@
     {% block extrahead %}
       {# Extra header stuff (scripts, styles, metadata, etc) seen by all browsers. Use the 'page_css' block for CSS you want to hide from IE8 and lower. #}
     {% endblock %}
+    <script>
+      window.siteLocale = "{{ LANG }}";
+    </script>
   </head>
 
   <body {% if self.body_id() %}id="{% block body_id %}{% endblock %}" {% endif %}class="html-{{ DIR }} {% block body_class %}{% endblock %}" {% block body_attrs %}{% endblock %}>


### PR DESCRIPTION
Resolves #379 

If the supporter has checked "Subscribe to Newsletter" during the donation flow, then redirect them to the newsletter page. This flow might be a bit jarring, but it's probably a good idea to do immediately and not defer it to a `checkoutClose`, as the supporter might close the window on the "Thank you" screen and miss the newsletter redirect entirely.

This also includes a global variable to pull/reference the current site locale. (window.siteLocale) Prevents me from having to do url splicing.