### PR TITLE
Redirect to the newsletter page if window.open === null

### DIFF
--- a/assets/js/common/donations.js
+++ b/assets/js/common/donations.js
@@ -64,7 +64,13 @@ if (typeof Mozilla === 'undefined') {
             const hasSubscribedToNewsletter = details.supporter.mailingListSubscribed || false;
 
             if (hasSubscribedToNewsletter) {
-                window.open(`/${window.siteLocale}/newsletter`, '_blank');
+                const url = `/${window.siteLocale}/newsletter`;
+                const opener = window.open(url, '_blank');
+
+                // If a browser doesn't want us to open a new tab (due to a pop-up blocker, or chrome's 'user must click once on a page before we allow redirect') then just redirect them.
+                if (opener === null) {
+                    location.href = url;
+                }
             }
         });
     }


### PR DESCRIPTION
Resolves #381 

While testing we noticed mobile safari didn't open a new tab, this might be the case in other browsers. So check the opener value, and if it's null redirect them. A little clunky, but it should work. 

If we want to get fancy, can add a " :tada: Thank you for donating! :tada: " message to the newsletter page if they arrive from the donation flow.

I had to resurrect the docker branch to get an ssl local environment to do a test donation (since FRU only functions under ssl.) I've tested this on desktop Firefox (new tab), desktop Chrome (new tab), desktop Safari (new tab), mobile safari (redirection).