### PR TITLE
Migration script to import localized strings from give.thunderbird.net

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ thunderbird_notes
 thunderbird.net
 site
 webenv
+tmp

--- a/l10n_tools/import_wagtail_donation_strings.py
+++ b/l10n_tools/import_wagtail_donation_strings.py
@@ -144,7 +144,7 @@ def push_strings(localized_strings, locale, directory):
         if not any(conditions):
             continue
 
-        if entry.msgid in localized_strings:
+        if entry.msgid in localized_strings and entry.msgstr is None:
             entry.msgstr = localized_strings[entry.msgid]
 
     po_file.save(localized_po)

--- a/l10n_tools/import_wagtail_donation_strings.py
+++ b/l10n_tools/import_wagtail_donation_strings.py
@@ -1,0 +1,155 @@
+#!/usr/bin/python
+import argparse
+import sys
+import polib
+import settings
+
+
+def main():
+    print("Give.thunderbird.net string importer script")
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run', help='Run this script without actually merging any strings', action='store_true', default=False)
+    parser.add_argument('--faq-project', help='Root project directory where the strings will be pulled from.', default='../tmp/thunderbird-donate-content')
+    parser.add_argument('--ways-to-give-project', default='../tmp/donate-l10n')
+    parser.add_argument('--tbnet-project', help='Root project directory where the strings will be merged into.', default='../locale')
+    args = parser.parse_args()
+
+    print("Running with --dry-run={}\n".format(args.dry_run))
+
+    locales = settings.FRU_LANGUAGES.keys()
+
+    reference_strings = retrieve_source_strings(args.tbnet_project)
+
+    for locale in locales:
+        if 'en-' in locale:
+            continue
+
+        # Folders use underscores
+        locale = locale.replace('-', '_')
+
+        faq_localized = pull_strings_faq(reference_strings, locale, args.faq_project)
+        ways_to_give_localized = pull_strings_ways_to_give(reference_strings, locale, args.ways_to_give_project)
+
+        localized = faq_localized.copy()
+        localized.update(ways_to_give_localized)
+
+        if not args.dry_run:
+            push_strings(localized, locale, args.tbnet_project)
+
+        print("[{}] {} strings were imported.".format(locale, len(localized)))
+
+    print ("Finished importing strings")
+
+
+def occurs_in(to_find, occurrences):
+    """Occurrences property is a list of tuples, first entry in the tuple is the filename and that's all we need."""
+    for occurrence in occurrences:
+        if to_find in occurrence[0]:
+            return True
+
+    return False
+
+
+def retrieve_source_strings(directory):
+    """Retrieve the source strings for faq.py, ways-to-give.html, and donate/index.html, so we can compare it later."""
+    source_po = "{}/templates/LC_MESSAGES/messages.pot".format(directory)
+
+    try:
+        po_file = polib.pofile(source_po)
+    except IOError:
+        print("! Could not load `messages.pot`")
+        # We can't proceed if we don't have the source strings...
+        sys.exit()
+
+    reference_strings = []
+
+    for entry in po_file:
+        if len(entry.occurrences) == 0:
+            continue
+
+        conditions = (
+            occurs_in('faq.py', entry.occurrences),
+            occurs_in('website/includes/ways-to-give.html', entry.occurrences),
+            occurs_in('website/donate/index.html', entry.occurrences),
+        )
+
+        if not any(conditions):
+            continue
+
+        reference_strings.append(entry.msgid)
+
+    return reference_strings
+
+
+def pull_strings_from_po(filename):
+    """Generator to load the file, and yield each entry"""
+    try:
+        po_file = polib.pofile(filename)
+    except IOError:
+        print("! Could not load `{}`".format(filename))
+        return
+
+    for entry in po_file:
+        yield entry
+
+
+def pull_strings_faq(reference_strings, locale, directory):
+    """Compare and retrieve the localized strings from the thunderbird specific faq."""
+    faq_po = "{}/locales/{}/pages/mozilla-donate/faq.po".format(directory, locale)
+
+    matched_strings = {}
+
+    for entry in pull_strings_from_po(faq_po):
+        if entry.msgid in reference_strings:
+            matched_strings[entry.msgid] = entry.msgstr
+
+    return matched_strings
+
+
+def pull_strings_ways_to_give(reference_strings, locale, directory):
+    """Compare and retrieve the localized strings from the thunderbird specific ways to give page."""
+    django_po = "{}/donate/locale/{}/LC_MESSAGES/django.po".format(directory, locale)
+
+    matched_strings = {}
+
+    for entry in pull_strings_from_po(django_po):
+        if not occurs_in('donate/thunderbird/templates/pages/core/ways_to_give_page.html', entry.occurrences):
+            continue
+
+        if entry.msgid in reference_strings:
+            matched_strings[entry.msgid] = entry.msgstr
+
+    return matched_strings
+
+
+def push_strings(localized_strings, locale, directory):
+    """Push the retrieved localized strings into their specific messages.po file."""
+    localized_po = "{}/{}/LC_MESSAGES/messages.po".format(directory, locale)
+
+    #
+    try:
+        po_file = polib.pofile(localized_po)
+    except IOError:
+        print("! Could not load `{}`".format(localized_po))
+        return False
+
+    for entry in po_file:
+        conditions = (
+            occurs_in('faq.py', entry.occurrences),
+            occurs_in('website/includes/ways-to-give.html', entry.occurrences),
+            occurs_in('website/donate/index.html', entry.occurrences),
+        )
+
+        if not any(conditions):
+            continue
+
+        if entry.msgid in localized_strings:
+            entry.msgstr = localized_strings[entry.msgid]
+
+    po_file.save(localized_po)
+    return True
+
+
+if __name__ == '__main__':
+    main()

--- a/l10n_tools/import_wagtail_donation_strings.py
+++ b/l10n_tools/import_wagtail_donation_strings.py
@@ -144,7 +144,8 @@ def push_strings(localized_strings, locale, directory):
         if not any(conditions):
             continue
 
-        if entry.msgid in localized_strings and entry.msgstr is None:
+        # If we have a match, and we're not going to override existing localization...
+        if entry.msgid in localized_strings and not entry.msgstr:
             entry.msgstr = localized_strings[entry.msgid]
 
     po_file.save(localized_po)

--- a/l10n_tools/readme.md
+++ b/l10n_tools/readme.md
@@ -16,7 +16,7 @@ This script will first load the messages.pot template file, pull in the msgid ke
 
 The localization for give.thunderbird.net is split into two different repos:
 - https://github.com/mozilla-l10n/thunderbird-donate-content
-- https://github.com/mozilla-l10n/mozilla-donate-content
+- https://github.com/mozilla-l10n/donate-l10n
 
 Pull those down (hint: by default the script looks in thunderbird-website/tmp), then extract the strings of the current thunderbird-website. Once that is done, run `import_wagtail_donation_script.py` from `l10n_tools/`.
 

--- a/l10n_tools/readme.md
+++ b/l10n_tools/readme.md
@@ -8,3 +8,16 @@ From this directory simply run:
 `./extract.sh`
 
 If you receive errors similar to: `mv: illegal option -t` or `find: -printf: unknown primary or operator`, then please see the above disclaimer about CoreUtils/FindUtils. You may need to temporarily modify the script to use `gmv`/`gfind`.  
+
+## Import Wagtail Donation String
+This is a temporary import script to seed the localization of the FAQ and Ways to Give page from give.thunderbird.net.
+
+This script will first load the messages.pot template file, pull in the msgid keys, and compare that against each locale's `faq.po` and `django.po` file. If it finds a match it will merge it into thunderbird's locale `messages.po` file.
+
+The localization for give.thunderbird.net is split into two different repos:
+- https://github.com/mozilla-l10n/thunderbird-donate-content
+- https://github.com/mozilla-l10n/mozilla-donate-content
+
+Pull those down (hint: by default the script looks in thunderbird-website/tmp), then extract the strings of the current thunderbird-website. Once that is done, run `import_wagtail_donation_script.py` from `l10n_tools/`.
+
+To prevent any conflicts, make the Pontoon project private and then push any strings up to Thunderbird's locale repo.


### PR DESCRIPTION
Part of #384 (the other half is running it.) 

Wrote a bit in the readme.md, but basically we grab source strings, do an exact string match with any msgids from give.thunderbird.net, and merge/save any of those matches.

Pulls in quite a few strings considering differences in html formatting, and updated copy. I was told the localizers will receive suggestions for similar strings on Pontoon, so that should cover the rest.

Local test run:
```
Give.thunderbird.net string importer script
Running with --dry-run=False

[fr] 31 strings were imported.
! Could not load `../tmp/thunderbird-donate-content/locales/nn_NO/pages/mozilla-donate/faq.po`
[nn_NO] 13 strings were imported.
[nl] 31 strings were imported.
! Could not load `../tmp/thunderbird-donate-content/locales/es_MX/pages/mozilla-donate/faq.po`
! Could not load `../tmp/donate-l10n/donate/locale/es_MX/LC_MESSAGES/django.po`
[es_MX] 0 strings were imported.
! Could not load `../tmp/thunderbird-donate-content/locales/pt_PT/pages/mozilla-donate/faq.po`
[pt_PT] 13 strings were imported.
! Could not load `../tmp/thunderbird-donate-content/locales/es_AR/pages/mozilla-donate/faq.po`
! Could not load `../tmp/donate-l10n/donate/locale/es_AR/LC_MESSAGES/django.po`
[es_AR] 0 strings were imported.
[de] 31 strings were imported.
[it] 31 strings were imported.
[da] 31 strings were imported.
! Could not load `../tmp/thunderbird-donate-content/locales/es_CL/pages/mozilla-donate/faq.po`
! Could not load `../tmp/donate-l10n/donate/locale/es_CL/LC_MESSAGES/django.po`
[es_CL] 0 strings were imported.
! Could not load `../tmp/thunderbird-donate-content/locales/pt_BR/pages/mozilla-donate/faq.po`
[pt_BR] 13 strings were imported.
! Could not load `../tmp/thunderbird-donate-content/locales/nb_NO/pages/mozilla-donate/faq.po`
[nb_NO] 13 strings were imported.
! Could not load `../tmp/thunderbird-donate-content/locales/sv_SE/pages/mozilla-donate/faq.po`
[sv_SE] 13 strings were imported.
! Could not load `../tmp/thunderbird-donate-content/locales/fi/pages/mozilla-donate/faq.po`
! Could not load `../tmp/donate-l10n/donate/locale/fi/LC_MESSAGES/django.po`
[fi] 0 strings were imported.
[hu] 31 strings were imported.
! Could not load `../tmp/thunderbird-donate-content/locales/es_ES/pages/mozilla-donate/faq.po`
! Could not load `../tmp/donate-l10n/donate/locale/es_ES/LC_MESSAGES/django.po`
[es_ES] 0 strings were imported.
! Could not load `../tmp/thunderbird-donate-content/locales/ja/pages/mozilla-donate/faq.po`
[ja] 13 strings were imported.
Finished importing strings
```