### PR TITLE
Enable A/B testing on Start Page (Fixes #395)

### DIFF
--- a/assets/js/common/ab-testing.js
+++ b/assets/js/common/ab-testing.js
@@ -103,8 +103,9 @@ if (typeof Mozilla === 'undefined') {
             const utmSource = element.getAttribute('data-donate-source') || 'thunderbird.net';
             const utmMedium = element.getAttribute('data-donate-medium') || 'fru';
             const utmCampaign = element.getAttribute('data-donate-campaign') || 'donation_flow_2023';
+            const redirect = element.hasAttribute('data-donate-redirect') || false;
 
-            element.href = window.Mozilla.Donation.MakeDonateUrl(utmContent, utmSource, utmMedium, utmCampaign);
+            element.href = window.Mozilla.Donation.MakeDonateUrl(utmContent, utmSource, utmMedium, utmCampaign, redirect);
         }
     }
 

--- a/assets/js/common/donations.js
+++ b/assets/js/common/donations.js
@@ -31,7 +31,6 @@ if (typeof Mozilla === 'undefined') {
      */
     Donation.Init = function() {
         if (!window.FundraiseUp) {
-            console.error("Could not find FundraiseUp");
             return;
         }
 
@@ -99,21 +98,31 @@ if (typeof Mozilla === 'undefined') {
      * @param utmSource {?string}
      * @param utmMedium {?string}
      * @param utmCampaign {?string}
+     * @param redirect {boolean} - For the start page, redirects to www.thunderbird.net/donate/
      */
-    Donation.MakeDonateUrl = function(utmContent = null, utmSource = 'thunderbird.net', utmMedium = 'fru', utmCampaign = 'donation_flow_2023') {
+    Donation.MakeDonateUrl = function(utmContent = null, utmSource = 'thunderbird.net', utmMedium = 'fru', utmCampaign = 'donation_flow_2023', redirect = false) {
         let params = {
-            'form': 'support',
+            // Don't open the form automatically if we're redirecting
+            'form': redirect ? null : 'support',
             'utm_content': utmContent,
             'utm_source': utmSource,
             'utm_medium': utmMedium,
             'utm_campaign': utmCampaign
         };
+
         // Filter nulls from the object (this mutates)
         Object.keys(params).forEach((k) => params[k] == null && delete params[k]);
 
         params = new URLSearchParams(params);
 
-        return `?${params.toString()}`;
+        const query_params = `?${params.toString()}`;
+
+        if (redirect) {
+            // We don't have a good way to get the current environment in javascript right now..
+            return `https://www.thunderbird.net/donate/${query_params}#donate`;
+        }
+
+        return query_params;
     }
 
     /**

--- a/build-site.py
+++ b/build-site.py
@@ -27,7 +27,7 @@ else:
 
 if args.startpage:
     print('Rendering start page ' + langmsg)
-    site = builder.Site(languages, settings.START_PATH, settings.START_RENDERPATH, settings.START_CSS, debug=args.debug)
+    site = builder.Site(languages, settings.START_PATH, settings.START_RENDERPATH, settings.START_CSS, js_bundles=settings.START_JS, debug=args.debug)
     site.build_startpage()
 else:
     print('Rendering www.thunderbird.net ' + langmsg)

--- a/settings.py
+++ b/settings.py
@@ -196,6 +196,13 @@ START_CSS = {
     'start-style': ['less.old/sandstone/fonts.less', 'less.old/thunderbird/start.less']
 }
 
+START_JS = {
+    'common-bundle': [
+        # Load bearing order..Donation must come before AB testing.
+        'js/common/donations.js', 'js/common/ab-testing.js'
+    ]
+}
+
 CURRENCIES = {
     # Second value is the default.
     'brl': {'symbol': 'R$', 'presets': ['80', '40', '20', '10'], 'default': '40'},

--- a/start-page/_base-resp.html
+++ b/start-page/_base-resp.html
@@ -18,5 +18,6 @@
     <main>
       {% block main %}{% endblock %}
     </main>
+    <script type="text/javascript" src="/media/js/common-bundle.js" charset="utf-8"></script>
   </body>
 </html>

--- a/start-page/_new-base-resp.html
+++ b/start-page/_new-base-resp.html
@@ -10,6 +10,7 @@
     <title>{% filter striptags|e %}{% block title %}{% endblock %}{% endfilter %}</title>
     {{ l10n_css() }}
     <link href="/media/css/new-start-style.css" rel="stylesheet" type="text/css" />
+    <script type="text/javascript" src="/media/js/common-bundle.js" charset="utf-8"></script>
   </head>
   <body class="start-bg">
     <main>
@@ -21,5 +22,6 @@
     <div class="logo-wireframe-dark">
       {{ svg('logo-wireframe-dark') }}
     </div>
+    <script type="text/javascript" src="/media/js/common-bundle.js" charset="utf-8"></script>
   </body>
 </html>

--- a/start-page/beta/index.html
+++ b/start-page/beta/index.html
@@ -17,7 +17,7 @@
 
           <div class="donate">
             {{ _('Support us!') }}
-            {{ '<a href="%(donate)s" class="donate-btn">'|format(donate=donate_url('paragraph_text', 'start_page_tb_beta')) }}
+            {{ '<a href="%(donate)s" class="donate-btn" data-donate-btn data-donate-redirect data-donate-content="paragraph_text" data-donate-source="start_page_tb_beta">'|format(donate=donate_url('paragraph_text', 'start_page_tb_beta')) }}
               {{ svg('donate-btn-heart') }}
               {{ _('Donate') }}
             </a>

--- a/start-page/daily/index.html
+++ b/start-page/daily/index.html
@@ -24,8 +24,8 @@
       </div>
       <div>
         <section>
-          <h2><i class="fas fa-heart fa-lg"  style="color:#ff0039"></i> {{ _('<a href="%(donate)s">Donate</a>')|format(donate=donate_url('heading', 'start_page_tb_daily')) }}</h2>
-          <p>{{ _('Thunderbird is both free and freedom respecting, but we\'re also completely funded by donations! The best way for you to ensure Thunderbird remains available and awesome is to <a href="%(donate)s">donate</a> so that the project can hire developers, pay for infrastructure, and continue to improve.')|format(donate=donate_url('paragraph_text', 'start_page_tb_daily')) }}</p>
+          <h2><i class="fas fa-heart fa-lg"  style="color:#ff0039"></i> {{ _('<a href="%(donate)s" data-donate-btn data-donate-redirect data-donate-content="heading" data-donate-source="start_page_tb_daily">Donate</a>')|format(donate=donate_url('heading', 'start_page_tb_daily')) }}</h2>
+          <p>{{ _('Thunderbird is both free and freedom respecting, but we\'re also completely funded by donations! The best way for you to ensure Thunderbird remains available and awesome is to <a href="%(donate)s" data-donate-btn data-donate-redirect data-donate-content="paragraph_text" data-donate-source="start_page_tb_daily">donate</a> so that the project can hire developers, pay for infrastructure, and continue to improve.')|format(donate=donate_url('paragraph_text', 'start_page_tb_daily')) }}</p>
         </section>
         <section>
           <h2><i class="fas fa-hands-helping fa-lg" style="color:#ed00b5"></i> {{ _('<a href="%(contribute)s">Get Involved</a>')|format(contribute='https://www.thunderbird.net/get-involved/') }}</h2>

--- a/start-page/release/index.html
+++ b/start-page/release/index.html
@@ -17,7 +17,7 @@
 
           <div class="donate">
             {{ _('Support us!') }}
-            {{ '<a href="%(donate)s" class="donate-btn">'|format(donate=donate_url('paragraph_text', 'start_page_tb_release')) }}
+            {{ '<a href="%(donate)s" class="donate-btn" data-donate-btn data-donate-redirect data-donate-content="paragraph_text" data-donate-source="start_page_tb_release">'|format(donate=donate_url('paragraph_text', 'start_page_tb_release')) }}
               {{ svg('donate-btn-heart') }}
               {{ _('Donate') }}
             </a>
@@ -33,7 +33,7 @@
               {{ _('Support Us') }}
             </h2>
             <p>{{ _('Thank you for supporting Thunderbird, which is funded by users like you! Producing Thunderbird requires software engineers, designers, system administrators and server infrastructure. So if you like Thunderbird, the best way to ensure Thunderbird remains available is to make a donation.') }}</p>
-            {{ '<a href="%(donate)s" class="donate">'|format(donate=donate_url('paragraph_text', 'start_page_tb_release')) }}
+            {{ '<a href="%(donate)s" class="donate" data-donate-btn data-donate-redirect data-donate-content="paragraph_text" data-donate-source="start_page_tb_release">'|format(donate=donate_url('paragraph_text', 'start_page_tb_release')) }}
               {{ _('Donate') }}
               {{ svg('external-link') }}
             </a>


### PR DESCRIPTION
Enable A/B testing on Start Page (Fixes #395) 
 - Builds and attaches a JS bundle for start-page (only contains ab-test and donation modules)
 - Adjusted javascript to redirect if `data-donate-redirect` attribute is found on the donation button
 - This redirect is sadly hardcoded for production
 - Removed an intentional javascript error if window.FundraiseUp is missing since start-page won't have it

I'd fix the load bearing javascript bundle due to AB-Test's donation link changer, by having it wait for a 'Donation.Init is done' event. But it works this way for now for this AB-Test.