### PR TITLE
Track which bucket the AB Test throws us in (Fixes #397)

### DIFF
--- a/assets/js/common/ab-testing.js
+++ b/assets/js/common/ab-testing.js
@@ -12,7 +12,7 @@ if (typeof Mozilla === 'undefined') {
      * Bucket === 1 - give.thunderbird.net
      */
     const ABTest = {};
-    ABTest.bucket = 0;
+    ABTest.bucket = null;
 
     ABTest.RandomInt = function(min, max) {
         return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -20,9 +20,30 @@ if (typeof Mozilla === 'undefined') {
 
     /**
      * Pick a random int between 0 - 1.
+     * Once a bucket has been chosen, this function does nothing.
      */
     ABTest.Choose = function() {
+        if (ABTest.bucket !== null) {
+            return;
+        }
+
         ABTest.bucket = ABTest.RandomInt(0, 1);
+    }
+
+    /**
+     * Tracks our bucket choice.
+     * Called from matomo.js, registers a bucket if no bucket has been chosen.
+     */
+    ABTest.Track = function() {
+        if (ABTest.bucket === null) {
+            ABTest.Choose();
+        }
+
+        // Initialize the command queue if it's somehow not.
+        const _paq = window._paq = window._paq || [];
+
+        // TrackEvent: Category, Action, Name, Value
+        _paq.push(['trackEvent', 'AB-Test', 'Bucket Registration', 'Donation Flow 2023', ABTest.bucket === 0 ? 'fru' : 'give']);
     }
 
     /**

--- a/media/js/matomo.js
+++ b/media/js/matomo.js
@@ -7,3 +7,6 @@ _paq.push(["setCookieDomain", "*.thunderbird.net"]);
 _paq.push(['setDownloadClasses', "download-link"]);
 _paq.push(['trackPageView']);
 _paq.push(['enableLinkTracking']);
+if (window.Mozilla.ABTest) {
+  window.Mozilla.ABTest.Track();
+}


### PR DESCRIPTION
Resolves #397 

Sends an event like:
<img width="229" alt="image" src="https://user-images.githubusercontent.com/97147377/219484005-74a456bb-b212-49d5-84ff-a552b5683813.png">

We call ABTest.Track after matomo sets up. ABTest is initialized well before matomo.js, so there shouldn't be any issues here. But I could setup a custom event (of like 'matomo.ready') if that sits better. 