### PR TITLE
Adjust download link events for the FRU flow. This does not affect gi…

### DIFF
--- a/assets/js/common/ab-testing.js
+++ b/assets/js/common/ab-testing.js
@@ -44,6 +44,13 @@ if (typeof Mozilla === 'undefined') {
 
         // TrackEvent: Category, Action, Name
         _paq.push(['trackEvent', 'AB-Test - Donation Flow 2023', 'Bucket Registration', ABTest.bucket === 0 ? 'fru' : 'give']);
+
+        // If we're in the FRU bucket, we need to adjust the download link class
+        if (ABTest.IsInFundraiseUpBucket()) {
+            _paq.push(['setDownloadClasses', "donate-download-link"]);
+            // This removes the download event on the Daily download button
+            _paq.push(['removeDownloadExtensions', ['dmg', 'tar.bz2', 'exe']])
+        }
     }
 
     /**

--- a/assets/js/common/donations.js
+++ b/assets/js/common/donations.js
@@ -55,6 +55,10 @@ if (typeof Mozilla === 'undefined') {
                 return;
             }
 
+            // Make sure _paq exists, and then send off the download event
+            window._paq = window._paq || [];
+            window._paq.push(['trackLink', download_link, 'download']);
+
             // Timeout is here to prevent url collisions with fundraiseup form.
             window.setTimeout(function() {
                 window.open(download_link, '_self');

--- a/website/includes/donate-modal.html
+++ b/website/includes/donate-modal.html
@@ -49,7 +49,7 @@
         </span>
         <p>{{ _('Donate & Download') }}</p>
       </a>
-      <a href="#" class="btn-body btn-secondary" id="amount-cancel">
+      <a href="#" class="btn-body btn-secondary donate-download-link" id="amount-cancel">
         <p>{{ _('No Thanks, Download Now!') }}</p>
         <span>
           <svg viewBox="0 0 7 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">


### PR DESCRIPTION
…ve flow. (Fixes #400)

Core idea is we want to change which class matomo tracks as the download link for the FRU bucket only. We have to use an extra javascript command queue call, otherwise we'd be getting download=thunderbird.net?form=support if they hit "Donate". lol. 

Only noticed this when looking at the visitor log. It's also a little bolted on, but it additional code in track will be moved to matomo.js once the AB test ends. 

I removed the file extensions so that `Download Daily` button doesn't also fire the download event. Again this only happens on FRU flow.

