### PR TITLE
Redirect downloads to /downloads (Fixes #403)

### DIFF
--- a/assets/js/common/ab-testing.js
+++ b/assets/js/common/ab-testing.js
@@ -44,13 +44,6 @@ if (typeof Mozilla === 'undefined') {
 
         // TrackEvent: Category, Action, Name
         _paq.push(['trackEvent', 'AB-Test - Donation Flow 2023', 'Bucket Registration', ABTest.bucket === 0 ? 'fru' : 'give']);
-
-        // If we're in the FRU bucket, we need to adjust the download link class
-        if (ABTest.IsInFundraiseUpBucket()) {
-            _paq.push(['setDownloadClasses', "donate-download-link"]);
-            // This removes the download event on the Daily download button
-            _paq.push(['removeDownloadExtensions', ['dmg', 'tar.bz2', 'exe']])
-        }
     }
 
     /**
@@ -73,6 +66,7 @@ if (typeof Mozilla === 'undefined') {
      * FundraiseUp's download functionality. This will simply raise the Donation form.
      * @param download_url
      * @private
+     * @deprecated Might be removed in a later release
      */
     ABTest._FundraiseUpDownload = function(download_url) {
         window.Mozilla.Donation.DisplayDownloadForm(download_url);
@@ -107,10 +101,7 @@ if (typeof Mozilla === 'undefined') {
         const download_url = element.href;
         const donate_url = element.dataset.donateLink || null;
 
-        if (ABTest.IsInFundraiseUpBucket()) {
-            event.preventDefault();
-            ABTest._FundraiseUpDownload(download_url);
-        } else {
+        if (ABTest.IsInGiveBucket()) {
             ABTest._GiveDownload(download_url, donate_url);
         }
     }
@@ -131,7 +122,7 @@ if (typeof Mozilla === 'undefined') {
             const utmSource = element.getAttribute('data-donate-source') || 'thunderbird.net';
             const utmMedium = element.getAttribute('data-donate-medium') || 'fru';
             const utmCampaign = element.getAttribute('data-donate-campaign') || 'donation_flow_2023';
-            const redirect = element.hasAttribute('data-donate-redirect') || false;
+            const redirect = element.getAttribute('data-donate-redirect') || null;
 
             element.href = window.Mozilla.Donation.MakeDonateUrl(utmContent, utmSource, utmMedium, utmCampaign, redirect);
         }
@@ -150,9 +141,12 @@ if (typeof Mozilla === 'undefined') {
         for (const donate_button of donate_buttons) {
             ABTest.ReplaceDonateLinks(donate_button);
         }
-        // Replace the download and donate button's link with the correct one.
-        const download_and_donate_button = document.getElementById('amount-submit');
-        ABTest.ReplaceDonateLinks(download_and_donate_button);
+
+        // Replace the download button's links with our download redirect
+        const download_buttons = document.querySelectorAll('.download-link');
+        for (const download_button of download_buttons) {
+            ABTest.ReplaceDonateLinks(download_button);
+        }
     }
 
     window.Mozilla.ABTest = ABTest;

--- a/assets/js/common/autodownload.js
+++ b/assets/js/common/autodownload.js
@@ -8,9 +8,26 @@
     // Only do this on the autodownload page.
     if ($('body').attr('id') == 'thunderbird-download') {
         var isIELT9 = window.Mozilla.Client.platform === 'windows' && /MSIE\s[1-8]\./.test(navigator.userAgent);
-        var $directDownloadLink = $('#direct-download-link');
-        var $platformLink = $('#download-button-desktop-release .download-list li:visible .download-link');
         var downloadURL;
+        var downloadChannelRegex = /download_channel=(esr|beta|daily)/;
+        var downloadChannel = downloadChannelRegex.exec(window.location.search);
+        var downloadElement = null;
+        var $platformLink = null;
+
+        // If it's not in the url, default it to esr
+        if (downloadChannel === null) {
+            downloadChannel = 'esr';
+        } else {
+            downloadChannel = downloadChannel[1];
+        }
+
+        // Each element as an id equal to their channel so: #esr, #beta, #daily.
+        downloadElement = document.getElementById(downloadChannel);
+        // Remove our display:hidden class
+        downloadElement.className = '';
+
+        // Get the platform link via the active downloadChannel
+        $platformLink = $(`#${downloadChannel} li:visible .download-link`);
 
         // Only auto-start the download if a visible platform link is detected.
         if ($platformLink.length) {

--- a/start-page/beta/index.html
+++ b/start-page/beta/index.html
@@ -17,7 +17,7 @@
 
           <div class="donate">
             {{ _('Support us!') }}
-            {{ '<a href="%(donate)s" class="donate-btn" data-donate-btn data-donate-redirect data-donate-content="paragraph_text" data-donate-source="start_page_tb_beta">'|format(donate=donate_url('paragraph_text', 'start_page_tb_beta')) }}
+            {{ '<a href="%(donate)s" class="donate-btn" data-donate-btn data-donate-redirect="donate" data-donate-content="paragraph_text" data-donate-source="start_page_tb_beta">'|format(donate=donate_url('paragraph_text', 'start_page_tb_beta')) }}
               {{ svg('donate-btn-heart') }}
               {{ _('Donate') }}
             </a>

--- a/start-page/daily/index.html
+++ b/start-page/daily/index.html
@@ -24,8 +24,8 @@
       </div>
       <div>
         <section>
-          <h2><i class="fas fa-heart fa-lg"  style="color:#ff0039"></i> {{ _('<a href="%(donate)s" data-donate-btn data-donate-redirect data-donate-content="heading" data-donate-source="start_page_tb_daily">Donate</a>')|format(donate=donate_url('heading', 'start_page_tb_daily')) }}</h2>
-          <p>{{ _('Thunderbird is both free and freedom respecting, but we\'re also completely funded by donations! The best way for you to ensure Thunderbird remains available and awesome is to <a href="%(donate)s" data-donate-btn data-donate-redirect data-donate-content="paragraph_text" data-donate-source="start_page_tb_daily">donate</a> so that the project can hire developers, pay for infrastructure, and continue to improve.')|format(donate=donate_url('paragraph_text', 'start_page_tb_daily')) }}</p>
+          <h2><i class="fas fa-heart fa-lg"  style="color:#ff0039"></i> {{ _('<a href="%(donate)s" data-donate-btn data-donate-redirect="donate" data-donate-content="heading" data-donate-source="start_page_tb_daily">Donate</a>')|format(donate=donate_url('heading', 'start_page_tb_daily')) }}</h2>
+          <p>{{ _('Thunderbird is both free and freedom respecting, but we\'re also completely funded by donations! The best way for you to ensure Thunderbird remains available and awesome is to <a href="%(donate)s" data-donate-btn data-donate-redirect="donate" data-donate-content="paragraph_text" data-donate-source="start_page_tb_daily">donate</a> so that the project can hire developers, pay for infrastructure, and continue to improve.')|format(donate=donate_url('paragraph_text', 'start_page_tb_daily')) }}</p>
         </section>
         <section>
           <h2><i class="fas fa-hands-helping fa-lg" style="color:#ed00b5"></i> {{ _('<a href="%(contribute)s">Get Involved</a>')|format(contribute='https://www.thunderbird.net/get-involved/') }}</h2>

--- a/start-page/release/index.html
+++ b/start-page/release/index.html
@@ -17,7 +17,7 @@
 
           <div class="donate">
             {{ _('Support us!') }}
-            {{ '<a href="%(donate)s" class="donate-btn" data-donate-btn data-donate-redirect data-donate-content="paragraph_text" data-donate-source="start_page_tb_release">'|format(donate=donate_url('paragraph_text', 'start_page_tb_release')) }}
+            {{ '<a href="%(donate)s" class="donate-btn" data-donate-btn data-donate-redirect="donate" data-donate-content="paragraph_text" data-donate-source="start_page_tb_release">'|format(donate=donate_url('paragraph_text', 'start_page_tb_release')) }}
               {{ svg('donate-btn-heart') }}
               {{ _('Donate') }}
             </a>
@@ -33,7 +33,7 @@
               {{ _('Support Us') }}
             </h2>
             <p>{{ _('Thank you for supporting Thunderbird, which is funded by users like you! Producing Thunderbird requires software engineers, designers, system administrators and server infrastructure. So if you like Thunderbird, the best way to ensure Thunderbird remains available is to make a donation.') }}</p>
-            {{ '<a href="%(donate)s" class="donate" data-donate-btn data-donate-redirect data-donate-content="paragraph_text" data-donate-source="start_page_tb_release">'|format(donate=donate_url('paragraph_text', 'start_page_tb_release')) }}
+            {{ '<a href="%(donate)s" class="donate" data-donate-btn data-donate-redirect="donate" data-donate-content="paragraph_text" data-donate-source="start_page_tb_release">'|format(donate=donate_url('paragraph_text', 'start_page_tb_release')) }}
               {{ _('Donate') }}
               {{ svg('external-link') }}
             </a>

--- a/website/download/beta/index.html
+++ b/website/download/beta/index.html
@@ -29,7 +29,7 @@
 
 {% block content %}
   <div class="justify-center flex">
-    {{ download_thunderbird(force_direct=true, alt_copy=_('Download Beta'), channel='beta', flex_class='justify-center') }}
+    {{ download_thunderbird(force_direct=true, alt_copy=_('Download Beta'), channel='beta', flex_class='justify-center', section='body') }}
   </div>
   <section id="shouldi" class="mt-20 mb-4 flex max-w-6xl mx-auto justify-center items-center pl-8 pr-8">
     <span class="header-line flex-1"></span>

--- a/website/download/index.html
+++ b/website/download/index.html
@@ -16,7 +16,16 @@
     <h1 class="font-4xl md:font-hero font-thin md:mt-10 mb-8">{{ self.page_title() }}</h1>
     <p class="font-lg md:font-xl tracking-wide leading-relaxed max-w-xl mb-8 md:mb-16">{{ self.page_desc() }}</p>
     <div class="tracking-wider">
-      {{ download_thunderbird(force_direct=true, alt_copy=_('Free Download')) }}
+      <!-- Hide all the possible channels, so we can later show the one we want. -->
+      <div id="esr" class="hidden">
+      {{ download_thunderbird(force_direct=true, alt_copy=_('Free Download'), flex_class='justify-center') }}
+      </div>
+      <div id="beta" class="hidden">
+      {{ download_thunderbird(force_direct=true, alt_copy=_('Free Download'), channel='beta', flex_class='justify-center') }}
+      </div>
+      <div id="daily" class="hidden">
+      {{ download_thunderbird(force_direct=true, alt_copy=_('Free Download'), channel='daily', flex_class='justify-center') }}
+      </div>
     </div>
   </section>
   <section class="hidden md:flex max-w-5xl self-center">

--- a/website/includes/download-button.html
+++ b/website/includes/download-button.html
@@ -14,7 +14,7 @@
     <ul class="list-none p-0 flex flex-wrap max-w-lg {{ flex_class }}">
       {% for plat in builds -%}
         <li class="ml-3 mr-3">
-          <a href="{{ plat.download_link_direct or plat.download_link }}" class="download-link {{ button_class }}" data-donate-link="{{ donate_url('post_download', download=True) }}">
+          <a href="{{ plat.download_link_direct or plat.download_link }}" class="download-link {{ button_class }}" data-donate-redirect="download-{{ channel or 'esr' }}" data-donate-content="post_download" data-donate-link="{{ donate_url('post_download', download=True) }}">
             {{ plat.os_arch_pretty or plat.os_pretty }}
           </a>
         </li>
@@ -45,6 +45,8 @@
       <li class="os_{{ plat.os }}{% if plat.arch %} {{ plat.arch }}{% endif %} ml-3 mr-3">
         <a class="download-link {{ button_class }}"
           href="{{ plat.download_link }}"
+          data-donate-redirect="download-{{ channel or 'esr' }}"
+          data-donate-content="post_download"
           data-donate-link="{{ donate_url('post_download', download=True) }}"
           {% if plat.download_link_direct %}
             data-direct-link="{{ plat.download_link_direct }}"
@@ -66,9 +68,9 @@
   </ul>
   <p class="download-other download-other-desktop os_android os_ios os_linux os_linux64 os_osx os_win os_win64 os_winsha1 font-sm mt-0">
     {% if channel != 'daily' %}{# Daily doesn't have an all download page or release notes. #}
-      <a href="{{ thunderbird_url('all', channel) }}" class="small-link {% if channel or section == 'body' %} text-blue {% endif %}">{{ _('Systems &amp; Languages') }}</a> &bull;
-      <a href="{{ thunderbird_url('releasenotes', channel) }}" class="small-link {% if channel or section == 'body' %} text-blue {% endif %}">{{ _('What’s New') }}</a> &bull;
+      <a href="{{ thunderbird_url('all', channel) }}" class="small-link {% if section == 'body' %} text-blue {% endif %}">{{ _('Systems &amp; Languages') }}</a> &bull;
+      <a href="{{ thunderbird_url('releasenotes', channel) }}" class="small-link {% if section == 'body' %} text-blue {% endif %}">{{ _('What’s New') }}</a> &bull;
     {% endif %}
-    <a href="{{ url('privacy.notices.thunderbird') }}" class="small-link {% if channel or section == 'body' %} text-blue {% endif %}">{{ _('Privacy') }}</a>
+    <a href="{{ url('privacy.notices.thunderbird') }}" class="small-link {% if section == 'body' %} text-blue {% endif %}">{{ _('Privacy') }}</a>
   </p>
 </div>

--- a/website/includes/site-prefooter.html
+++ b/website/includes/site-prefooter.html
@@ -56,7 +56,7 @@
             {{ _('Thunderbird is a free email application that’s easy to set up and customize - and it’s loaded with great features!') }}
           </p>
           <aside class="ml-0 mr-0 self-start text-center text-green font-semibold">
-            {{ download_thunderbird(force_direct=true, alt_copy=_('Download Thunderbird')) }}
+            {{ download_thunderbird(force_direct=true, alt_copy=_('Download Thunderbird'), section='body') }}
           </aside>
         </main>
       </section>
@@ -71,7 +71,7 @@
             {{ _('Experience cutting edge features. Provide feedback to help refine and polish what will be in the final release.') }}
           </p>
           <aside class="ml-0 mr-0 self-start text-left text-blue font-semibold">
-            {{ download_thunderbird(force_direct=true, alt_copy=_('Download Beta'), channel='beta') }}
+            {{ download_thunderbird(force_direct=true, alt_copy=_('Download Beta'), channel='beta', section='body') }}
           </aside>
         </main>
       </section>
@@ -92,7 +92,7 @@
             {{ _('Daily is an unstable testing and development platform, make sure you back up important data regularly!') }}
           </p>
           <aside class="ml-0 mr-0 self-start text-center text-blue font-semibold">
-            {{ download_thunderbird(force_direct=true, alt_copy=_('Download Daily'), channel='daily') }}
+            {{ download_thunderbird(force_direct=true, alt_copy=_('Download Daily'), channel='daily', section='body') }}
           </aside>
         </main>
       </section>


### PR DESCRIPTION
A bunch of changes to accomendate download channels into the download page.

- This respects their download channel
- Removed _some_ unneeded FRU related work-arounds
- Adjusted the data-donate-redirect to be parameter based
- Updated start page to use the data-donate-redirect parameter of `donate`
- Default channel (if not specified) is `esr`
- Add lang to donate and download redirects

A little quirk is the "Free Download" button(s) on /download are still touched by our AB Test/Donation flow. So if someone is in the FRU bucket when they first click "Free Download" and are redirected here, and then are put in the give bucket, and click on the "Free Download" on the /download page, they will be sent to give.thunderbird.net (with the download)

Easy fix, I'm just not sure if we want to bother with that. 

Screenshots:
ESR
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/97147377/220747908-f77176f4-7e1b-4db0-a5f2-0fa546b3c837.png">
Beta
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/97147377/220747853-5527e489-94c2-483f-88d6-efcb89f24200.png">
Daily
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/97147377/220747719-970a44f8-2c0b-41d2-81cd-7d24858dc172.png">
