### PR TITLE
Adjust download tracking to work properly (Fixes #406)

### DIFF
--- a/assets/js/common/ab-testing.js
+++ b/assets/js/common/ab-testing.js
@@ -143,9 +143,18 @@ if (typeof Mozilla === 'undefined') {
         }
 
         // Replace the download button's links with our download redirect
-        const download_buttons = document.querySelectorAll('.download-link');
-        for (const download_button of download_buttons) {
-            ABTest.ReplaceDonateLinks(download_button);
+        // But only do that if we're not already on the download page
+        if (window.location.href.indexOf('/download/') === -1) {
+            const download_buttons = document.querySelectorAll('.download-link');
+            for (const download_button of download_buttons) {
+                ABTest.ReplaceDonateLinks(download_button);
+
+                // If we're in FRU bucket, don't trigger download events for our non-download page buttons
+                // Otherwise we'll be getting download==thunderbird.net instead of download==download.mozilla.org
+                if (ABTest.IsInFundraiseUpBucket()) {
+                    download_button.className = download_button.className.replace('matomo-track-download', '');
+                }
+            }
         }
     }
 

--- a/assets/js/common/autodownload.js
+++ b/assets/js/common/autodownload.js
@@ -33,6 +33,10 @@
         if ($platformLink.length) {
             downloadURL = $platformLink.attr('href');
 
+            window._paq = window._paq || [];
+            // Track auto downloads - trackLink( url, linkType )
+            window._paq.push(['trackLink', downloadURL, 'download'])
+
             // If user is not on an IE that blocks JS triggered downloads, start the
             // platform-detected download a second after DOM ready event. We don't rely on
             // the window load event as we have third-party tracking pixels.

--- a/media/js/matomo.js
+++ b/media/js/matomo.js
@@ -4,7 +4,7 @@ _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
 _paq.push(['setTrackerUrl', u+'piwik.php']);
 _paq.push(['setSiteId', '1']);
 _paq.push(["setCookieDomain", "*.thunderbird.net"]);
-_paq.push(['setDownloadClasses', "download-link"]);
+_paq.push(['setDownloadClasses', "matomo-track-download"]);
 _paq.push(['trackPageView']);
 _paq.push(['enableLinkTracking']);
 if (window.Mozilla.ABTest) {

--- a/media/js/matomo404.js
+++ b/media/js/matomo404.js
@@ -6,6 +6,6 @@ encodeURIComponent(document.location.pathname+document.location.search) +
 _paq.push(['setTrackerUrl', u+'piwik.php']);
 _paq.push(['setSiteId', '1']);
 _paq.push(["setCookieDomain", "*.thunderbird.net"]);
-_paq.push(['setDownloadClasses', "download-link"]);
+_paq.push(['setDownloadClasses', "matomo-track-download"]);
 _paq.push(['trackPageView']);
 _paq.push(['enableLinkTracking']);

--- a/website/includes/download-button.html
+++ b/website/includes/download-button.html
@@ -14,7 +14,7 @@
     <ul class="list-none p-0 flex flex-wrap max-w-lg {{ flex_class }}">
       {% for plat in builds -%}
         <li class="ml-3 mr-3">
-          <a href="{{ plat.download_link_direct or plat.download_link }}" class="download-link {{ button_class }}" data-donate-redirect="download-{{ channel or 'esr' }}" data-donate-content="post_download" data-donate-link="{{ donate_url('post_download', download=True) }}">
+          <a href="{{ plat.download_link_direct or plat.download_link }}" class="matomo-track-download download-link {{ button_class }}" data-donate-redirect="download-{{ channel or 'esr' }}" data-donate-content="post_download" data-donate-link="{{ donate_url('post_download', download=True) }}">
             {{ plat.os_arch_pretty or plat.os_pretty }}
           </a>
         </li>
@@ -43,7 +43,7 @@
   <ul class="download-list list-none p-0 flex flex-wrap max-w-lg mb-0 {{ flex_class }}">
     {% for plat in builds %}
       <li class="os_{{ plat.os }}{% if plat.arch %} {{ plat.arch }}{% endif %} ml-3 mr-3">
-        <a class="download-link {{ button_class }}"
+        <a class="matomo-track-download download-link {{ button_class }}"
           href="{{ plat.download_link }}"
           data-donate-redirect="download-{{ channel or 'esr' }}"
           data-donate-content="post_download"


### PR DESCRIPTION
- Swap our download class from `download-link` to `matomo-track-download`
- Add the additional `matomo-track-download` to our download links, so that javascript that relies on `.download-link` will not be disturbed
- Don't touch download links on the /download/ page
- Don't remove `matomo-track-download` if we're in the give bucket

A lot more snakey javascript blah, it'll be nice to clean this up after the test. 