### PR TITLE
Show the download button on the post download thank you

### DIFF
--- a/assets/js/common/autodownload.js
+++ b/assets/js/common/autodownload.js
@@ -21,9 +21,6 @@
 
     // Only do this on the autodownload page.
     if ($('body').attr('id') == 'thunderbird-download') {
-        if (!canAutodownload()) {
-            return;
-        }
         var downloadURL;
         var downloadChannelRegex = /download_channel=(esr|beta|daily)/;
         var downloadChannel = downloadChannelRegex.exec(window.location.search);
@@ -41,6 +38,11 @@
         downloadElement = document.getElementById(downloadChannel);
         // Remove our display:hidden class
         downloadElement.className = '';
+
+        // Make sure we've shown the appropriate download link before returning
+        if (!canAutodownload()) {
+            return;
+        }
 
         // Get the platform link via the active downloadChannel
         $platformLink = $(`#${downloadChannel} li:visible .download-link`);


### PR DESCRIPTION
Maybe a case where this function does too much. But let's make sure we show the download button before deciding whether we need to autodownload. My b. I should maybe kick-start that UI testing branch again. 