### PR TITLE
Basic UI testing via playwright, requires Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,28 @@ You can contribute to content translation of www.thunderbird.net pages using [Po
 # Donation FAQ
 
 The actual questions and answers part of the FAQ can be found in `./faq.py`. Make sure to include the `gettext` call, otherwise we won't be able to extract the strings for localization.
+
+# Tests
+
+## Pytest
+
+To run all tests use the command: 
+```
+python -m pytest tests/
+```
+
+## Playwright (via Pytest)
+
+Thunderbird-website uses Playwright via the Pytest plugin. For more information on the Playwright Python bindings [click here](https://playwright.dev/python/).
+
+Since the build script only works on Python 2 right now, you'll have to first build the site:
+```
+python2 build-site.py
+```
+
+To run just the playwright tests use the command:
+```
+python -m pytest tests/ui/
+```
+
+Playwright is setup to run UI tests under Firefox and Chromium. 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+
+[pytest]
+addopts = --browser firefox --browser chromium
+# webkit doesn't currently work?
+#  --browser webkit

--- a/settings.py
+++ b/settings.py
@@ -65,6 +65,10 @@ CANONICAL_LOCALES = {
     'zh-hant-hk': 'zh-TW',  # Bug 1338072
 }
 
+TEST_PORT = 8889
+TEST_URL_BASE = 'http://localhost:{}'.format(TEST_PORT)
+TEST_URL = '{}/{}'.format(TEST_URL_BASE, LANGUAGE_CODE)
+
 CANONICAL_URL = 'https://www.thunderbird.net'
 
 # url for the server that serves Thunderbird downloads.

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+import builder
+import settings
+
+
+@pytest.fixture(scope="session", autouse=True)
+def handle_server():
+    print("! Starting local test server at {}".format(settings.TEST_URL_BASE))
+    server = builder.setup_httpd(settings.TEST_PORT, settings.WEBSITE_RENDERPATH)
+    yield
+    print("! Shutting down local test server")
+    server.terminate()
+    server.join()
+

--- a/tests/ui/test_download_page.py
+++ b/tests/ui/test_download_page.py
@@ -1,0 +1,43 @@
+import re
+import pytest
+from playwright.sync_api import Page, expect
+from product_details import thunderbird_desktop
+import settings
+
+@pytest.fixture
+def download_page_download_states(page: Page):
+    """Returns a list of tuples, which contains the download page to goto, and the download version the visible download button should be."""
+    download_page_url = f"{settings.TEST_URL}/download/"
+
+    download_versions = (
+        thunderbird_desktop.latest_version('release'),
+        thunderbird_desktop.latest_version('beta'),
+        thunderbird_desktop.latest_version('daily')
+    )
+
+    return [
+        (download_page_url, download_versions[0]),
+        (f"{download_page_url}?downloaded=True", download_versions[0]),
+        (f"{download_page_url}?downloaded=False", download_versions[0]),
+        (f"{download_page_url}?download_channel=esr", download_versions[0]),
+        (f"{download_page_url}?download_channel=beta", download_versions[1]),
+        (f"{download_page_url}?download_channel=daily", download_versions[2]),
+        (f"{download_page_url}?download_channel=nonsense", download_versions[0]),
+        (f"{download_page_url}?download_channel=&downloaded=true&download_channel=beta", download_versions[1]),  # Javascript check looks for (esr|beta|daily), empty params are ignored
+        (f"{download_page_url}?download_channel=&downloaded=true&download_channel=daily&download_channel=beta", download_versions[2]),  # Javascript check will only use the first instance
+    ]
+
+
+def test_download_links_exist(page: Page, download_page_download_states):
+    """Tests the existence of the `Try Again` button on our download thank you page."""
+    for state in download_page_download_states:
+        page.goto(state[0])
+        expect(page.locator('.download-link:visible')).to_have_count(1)
+
+
+def test_download_links_are_correct(page: Page, download_page_download_states):
+    """Tests the validity of our download buttons when different download channels have been requested."""
+    for state in download_page_download_states:
+        page.goto(state[0])
+        expect(page.locator('.download-link:visible')).to_have_attribute("href", re.compile(state[1]))
+

--- a/tests/ui/test_local_server.py
+++ b/tests/ui/test_local_server.py
@@ -1,0 +1,14 @@
+import pytest
+import settings
+from playwright.sync_api import Page, expect
+
+
+def test_server_is_working(page: Page):
+    """Make sure our test server works correctly"""
+    response = page.goto(settings.TEST_URL)
+    assert response is not None
+    assert response.ok is True
+
+    # Make sure our title is correct, and this isn't an empty 200.
+    expect(page).to_have_title('Thunderbird — Make Email Easier. — Thunderbird')
+


### PR DESCRIPTION
Related ticket #5 

- Includes a dev server test
- Includes a few download button tests

Right now this just boots up the dev server, runs some playwright tests, and shuts down. If you make any changes you'll have to rebuild with Python2. Once we port the site to Python 3, I will add an optional pre-build step. 

There's no rush to merge this, I might just keep adding tests as bugs/new features come up though.