### PR TITLE
Replace references of Lightning Calendar to just Calendar

### DIFF
--- a/website/about/index.html
+++ b/website/about/index.html
@@ -34,7 +34,7 @@
       </aside>
 
       <aside class="hidden lg:flex flex-1 max-w-xl -mr-20">
-        {{ platform_img('thunderbird/calendar/screenshot.png', {'alt': _('Lightning Calendar screenshot'), 'high-res': True, 'l10n': True, 'platforms': ('windows', 'linux', 'mac')}) }}
+        {{ platform_img('thunderbird/calendar/screenshot.png', {'alt': _('Calendar screenshot'), 'high-res': True, 'l10n': True, 'platforms': ('windows', 'linux', 'mac')}) }}
       </aside>
     </section>
   </section>

--- a/website/calendar/holidays/index.html
+++ b/website/calendar/holidays/index.html
@@ -21,12 +21,12 @@
         <aside class="flex flex-col">
           {{ _('Holiday Calendars')}}
           <small class="font-normal font-md tracking-normal normal-case">
-            {{ _('Add your nation’s holidays to Lightning!') }}
+            {{ _('Add your nation’s holidays to Calendar!') }}
           </small>
         </aside>
       </h3>
       <p class="font-lg tracking-wider leading-loose mb-6 p-links-blue">
-        {{ _('We’ve got some holiday calendar files available for download. You can either download and then import them into Lightning or you can just subscribe to these calendars by copying their URL and then adding them as new remote calendar files. More information on installing a holiday calendar can be found in the <a href="%s">Adding a holiday calendar article</a>.')|format('https://support.mozilla.org/kb/adding-a-holiday-calendar') }}
+        {{ _('We’ve got some holiday calendar files available for download. You can either download and then import them into Calendar or you can just subscribe to these calendars by copying their URL and then adding them as new remote calendar files. More information on installing a holiday calendar can be found in the <a href="%s">Adding a holiday calendar article</a>.')|format('https://support.mozilla.org/kb/adding-a-holiday-calendar') }}
       </p>
       <p class="font-lg tracking-wider leading-loose mb-10 mt-0 p-links-blue">
         {{ _('You can also find calendars to subscribe to at <a href="%s">iCalShare.com</a>.')|format('http://icalshare.com') }}

--- a/website/calendar/index.html
+++ b/website/calendar/index.html
@@ -4,7 +4,7 @@
 
 {% extends "includes/base-resp.html" %}
 
-{% block page_title %}{{ _('Lightning Calendar') }}{% endblock %}
+{% block page_title %}{{ _('Calendar') }}{% endblock %}
 {% block page_desc %}{{ _('Organize your life — it&rsquo;s about time!') }}{% endblock %}
 
 {% block header_content %}
@@ -19,7 +19,7 @@
       <h3 class="header-section">
         <span>{{ svg('calendar') }}</span>
         <aside class="flex flex-col">
-          {{ _('Lightning Calendar')}}
+          {{ _('Calendar')}}
           <small class="font-normal font-md tracking-normal normal-case">
             {{ _('Organize your life — it’s about time!') }}
           </small>
@@ -32,7 +32,7 @@
     </aside>
 
     <aside class="w-3/5">
-      {{ platform_img('thunderbird/calendar/screenshot.png', {'alt': _('Lightning Calendar screenshot'), 'high-res': True, 'l10n': True, 'platforms': ('windows', 'linux', 'mac')}) }}
+      {{ platform_img('thunderbird/calendar/screenshot.png', {'alt': _('Calendar screenshot'), 'high-res': True, 'l10n': True, 'platforms': ('windows', 'linux', 'mac')}) }}
     </aside>
   </section>
 
@@ -47,7 +47,7 @@
             <aside class="flex flex-col font-lg">
               {{ _('Get Support')}}
               <small class="font-normal font-regular tracking-normal normal-case">
-                {{ _('Need help with Lightning?') }}
+                {{ _('Need help with Calendar?') }}
               </small>
             </aside>
           </h4>
@@ -84,7 +84,7 @@
       </aside>
 
       <aside class="flex flex-col w-1/2">
-        <a href="https://codetribute.mozilla.org/projects/calendar"
+        <a href="https://codetribute.mozilla.org/projects/thunderbird?project%3DCalendar%2520Frontend"
           class="flex flex-col btn-block-white m-2">
           <h4 class="header-section mb-0">
             <span>{{ svg('report') }}</span>


### PR DESCRIPTION
Replace references of the old Lightning Calendar to just Calendar, and correct some links so they point to the right place.

I thought about using Thunderbird Calendar, but Calendar seems to be the way it's referenced elsewhere.