### PR TITLE
Track donation start/completed events (Fixes #426)

### DIFF
--- a/assets/js/common/donations.js
+++ b/assets/js/common/donations.js
@@ -40,6 +40,9 @@ if (typeof Mozilla === 'undefined') {
          * @param details - See https://fundraiseup.com/docs/parameters/
          */
         fundraiseUp.on('checkoutOpen', function(details) {
+            window._paq = window._paq || [];
+            window._paq.push(['trackEvent', 'Donation', 'Started']);
+
             // Reset any stateful variables
             Donation.NeedsNewsletterRedirect = false;
 
@@ -51,8 +54,7 @@ if (typeof Mozilla === 'undefined') {
                 return;
             }
 
-            // Make sure _paq exists, and then send off the download event
-            window._paq = window._paq || [];
+            // Send off the download event
             window._paq.push(['trackLink', download_link, 'download']);
 
             // Timeout is here to prevent url collisions with fundraiseup form.
@@ -77,17 +79,25 @@ if (typeof Mozilla === 'undefined') {
          * @param details - See https://fundraiseup.com/docs/parameters/
          */
         fundraiseUp.on('donationComplete', function(details) {
-            if (!details || !details.supporter) {
+            if (!details) {
                 return;
             }
 
-            const hasSubscribedToNewsletter = details.supporter.mailingListSubscribed || false;
+            window._paq = window._paq || [];
 
-            if (hasSubscribedToNewsletter) {
-                const state = window.open(Donation.NEWSLETTER_URL, '_blank');
+            // TrackEvent: Category, Action, Name
+            window._paq.push(['trackEvent', 'Donation', 'Completed']);
+            window._paq.push(['trackGoal', 7]); // Donation Completed Goal
 
-                // If a browser doesn't want us to open a new tab (due to a pop-up blocker, or chrome's 'user must click once on a page before we allow redirect') then just redirect them.
-                Donation.NeedsNewsletterRedirect = state === null;
+            if (details.supporter) {
+                const hasSubscribedToNewsletter = details.supporter.mailingListSubscribed || false;
+
+                if (hasSubscribedToNewsletter) {
+                    const state = window.open(Donation.NEWSLETTER_URL, '_blank');
+
+                    // If a browser doesn't want us to open a new tab (due to a pop-up blocker, or chrome's 'user must click once on a page before we allow redirect') then just redirect them.
+                    Donation.NeedsNewsletterRedirect = state === null;
+                }
             }
         });
     }


### PR DESCRIPTION
Add donation tracking events to checkoutOpen and donationComplete. donationComplete also gets a trackGoal, we can see which one is more useful then axe the other later. 

Since checkoutOpen fires whenever the donation form is opened it can be a little spammy if someone closes and re-opens it a bunch. We could also use checkoutClosed, but that is still called after donationComplete.