### PR TITLE
Manually track the donation modal open goal (Fixes #441)

### DIFF
--- a/assets/js/common/donations.js
+++ b/assets/js/common/donations.js
@@ -32,6 +32,15 @@ if (typeof Mozilla === 'undefined') {
             return;
         }
 
+        // If a user clicks on a donate button, track the donate link click goal
+        const donateButtons = document.querySelectorAll('[data-donate-btn]');
+        donateButtons.forEach(function(element) {
+            element.addEventListener('click', function() {
+                window._paq = window._paq || [];
+                window._paq.push(['trackGoal', 1]);
+            });
+        });
+
         // Ensure we actually have the javascript loaded, so we can hook up our events.
         const fundraiseUp = window.FundraiseUp;
 


### PR DESCRIPTION
The event "Donation link click" broke when we removed give.thunderbird.net and switched to FRU. While we do track an event per modal open, we should also track the link clicks themselves, as 'checkoutOpen' is automatically opened in some cases. (Like after the download page.)
