### PR TITLE
Fixed blog card overflow caused by fixed-size image.

### DIFF
--- a/assets/less/components/links.less
+++ b/assets/less/components/links.less
@@ -106,7 +106,9 @@ a {
 
     img {
       width: auto;
-      height: 200px;
+      height: auto;
+      max-width: 100%;
+      max-height: 200px;
     }
   }
 


### PR DESCRIPTION
Updated styling for blog thumbnail images to ensure proper image scaling so cards don't overflow on small screen sizes.
| Device | Before | After |
| --- | --- | ---|
| Desktop (Changes have no effect) | <img src="https://github.com/thundernest/thunderbird-website/assets/33368366/3dd3fa42-f36f-43f6-a717-fc46954f1a86" alt="Desktop - Before" width="250px"> | <img src="https://github.com/thundernest/thunderbird-website/assets/33368366/7329d406-8509-407d-908c-8ab14730a705" alt="Desktop - After" width="250px"> |
| Pixel 4a | <img src="https://github.com/thundernest/thunderbird-website/assets/33368366/3e7aa047-c173-448c-8616-374a98aa7826" alt="Pixel 4a - Before" width="250px"> | <img src="https://github.com/thundernest/thunderbird-website/assets/33368366/b9cd0003-3d20-4326-9c25-3f270010445c" alt="Pixel 4a - After" width="250px"> |
iPhone SE 2 (Simulated) | <img src="https://github.com/thundernest/thunderbird-website/assets/33368366/ea3852f4-c3df-4de3-a59d-100f416851ac" alt="iPhone SE 2 (Simulated) - Before" width="250px"> | <img src="https://github.com/thundernest/thunderbird-website/assets/33368366/c295f136-552f-402c-aac5-62ff0c6343cb" alt="iPhone SE 2 (Simulated) - After" width="250px"> |



