### PR TITLE
Add a link showing how to get the new "Supernova" look.

### DIFF
--- a/media/css/115release.css
+++ b/media/css/115release.css
@@ -373,6 +373,27 @@ input[type="range"]::-webkit-range-thumb {
   transform: rotate(-45deg);
 }
 
+.caption-ln {
+  margin-block: 9px;
+  color: currentColor;
+  text-decoration-color: currentColor;
+  text-underline-offset: 0.25em;
+  text-decoration-thickness: .12em;
+  text-decoration-style: dotted;
+  transition: font-size .2s,
+              text-decoration-color .2s;
+}
+
+.caption-ln.donate,
+.caption-ln:hover,
+.caption-ln:hover:visited {
+  text-decoration-color: var(--color-blue-50);
+}
+
+.caption-ln:visited {
+  text-decoration-color: var(--color-purple-50);
+}
+
 .info p {
   color: var(--info-txt);
   font-weight: 500;

--- a/website/thunderbird/115.0/whatsnew/index.html
+++ b/website/thunderbird/115.0/whatsnew/index.html
@@ -35,7 +35,10 @@
         <div class="slider-tab"></div>
       </div>
     </figure>
-    <figcaption>115 | 102</figcaption>
+    <figcaption class="text-center">
+      115 | 102
+      <a class="block caption-ln" href="https://blog.thunderbird.net/2023/08/make-thunderbird-yours-how-to-get-the-thunderbird-115-supernova-look/">{{_('Learn how to get the new look')}}</a>
+    </figcaption>
   </section>
 
   <div class="nebula"><img src="/media/img/thunderbird/backgrounds/nebula.png" alt="{{_('A nebula of stars')}}"></div>


### PR DESCRIPTION
Add a link to the [blog post](https://blog.thunderbird.net/2023/08/make-thunderbird-yours-how-to-get-the-thunderbird-115-supernova-look/) showing how to get the new look shown in the before / after slider.


<img width="1474" alt="Screenshot 2023-08-14 at 10 06 24 AM" src="https://github.com/thundernest/thunderbird-website/assets/10608836/fb5aa94a-065b-46fc-b68c-851c8f4600e9">
