### PR TITLE
Allow the "Your Email" placeholder text to be localized.

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -381,7 +381,7 @@ with great features!') }}{% endblock %}
         <!-- Begin Mailchimp Signup Form -->
         <form action="https://thunderbird.us12.list-manage.com/subscribe?u=f8051cc8637cf3ff79661f382&amp;id=56428f2efc"
           class="newsletter-form" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form">
-          <input id="mce-EMAIL" name="EMAIL" type="email" placeholder="Your Email" required="">
+          <input id="mce-EMAIL" name="EMAIL" type="email" placeholder="{{ _('Your Email') }}" required="">
           <button type="submit" id="mc-embedded-subscribe" class="btn-newsletter btn-newsletter-text">{{_('Subscribe')}}</button>
           <button type="submit" id="mc-embedded-subscribe" class="btn-newsletter btn-newsletter-icon">➜</button>
           <!-- Prevent Bot signups -->


### PR DESCRIPTION
Fixes #486

Simple fix, easy spot to miss. I'll push up the updated locale files once this gets merged in.