### PR TITLE
Display the old download links below the download button on the frontpage

### DIFF
--- a/assets/css/115-homepage.css
+++ b/assets/css/115-homepage.css
@@ -685,10 +685,6 @@ button:hover::after {
   margin-block: 40px;
 }
 
-p.download-other.download-other-desktop.os_android.os_ios.os_linux.os_linux64.os_osx.os_win.os_win64.os_winsha1 {
-  display: none !important;
-}
-
 .site-nav {
   box-sizing: border-box;
   position: fixed;
@@ -1481,4 +1477,14 @@ footer {
   .btn-newsletter-icon {
     display: inline-block;
   }
+}
+
+.download-other {
+  text-align: center;
+  transform: translateX(20px);
+  margin-top: -1rem;
+}
+
+.small-link {
+  font-size: 80%;
 }

--- a/website/includes/download-button.html
+++ b/website/includes/download-button.html
@@ -69,11 +69,15 @@
   </ul>
   {% if not hide_footer_links %}
   <p class="download-other download-other-desktop os_android os_ios os_linux os_linux64 os_osx os_win os_win64 os_winsha1 font-sm mt-0">
-    {% if channel != 'daily' %}{# Daily doesn't have an all download page or release notes. #}
-      <a href="{{ thunderbird_url('all', channel) }}" class="small-link {% if section == 'body' %} text-blue {% endif %}">{{ _('Systems &amp; Languages') }}</a> &bull;
-      <a href="{{ thunderbird_url('releasenotes', channel) }}" class="small-link {% if section == 'body' %} text-blue {% endif %}">{{ _('What’s New') }}</a> &bull;
+    {% if section == 'new-frontpage' %}{# New frontpage should only display System & Languages #}
+      <a href="{{ thunderbird_url('all', channel) }}" class="small-link {% if section == 'body' %} text-blue {% endif %}">{{ _('Systems &amp; Languages') }}</a>
+    {% else %}
+      {% if channel != 'daily' %}{# Daily doesn't have an all download page or release notes. #}
+        <a href="{{ thunderbird_url('all', channel) }}" class="small-link {% if section == 'body' %} text-blue {% endif %}">{{ _('Systems &amp; Languages') }}</a> &bull;
+        <a href="{{ thunderbird_url('releasenotes', channel) }}" class="small-link {% if section == 'body' %} text-blue {% endif %}">{{ _('What’s New') }}</a> &bull;
+      {% endif %}
+      <a href="{{ url('privacy.notices.thunderbird') }}" class="small-link {% if section == 'body' %} text-blue {% endif %}">{{ _('Privacy') }}</a>
     {% endif %}
-    <a href="{{ url('privacy.notices.thunderbird') }}" class="small-link {% if section == 'body' %} text-blue {% endif %}">{{ _('Privacy') }}</a>
   </p>
   {% endif %}
 </div>

--- a/website/includes/new/page.html
+++ b/website/includes/new/page.html
@@ -25,7 +25,7 @@
         <a href="{{ donate_url('header') }}" class="nav-ln" data-donate-btn
           data-donate-content="header">{{_('Donate')}}</a>
         <div>
-          {{ download_thunderbird(force_direct=true, alt_copy=_('Download')) }}
+          {{ download_thunderbird(force_direct=true, hide_footer_links=true, alt_copy=_('Download')) }}
         </div>
       </div>
     </div>

--- a/website/index.html
+++ b/website/index.html
@@ -36,7 +36,7 @@ with great features!') }}{% endblock %}
           </span>
         </div>
         <div>
-        {{ download_thunderbird(force_direct=true, alt_copy=_('Download')) }}
+        {{ download_thunderbird(force_direct=true, alt_copy=_('Download'), section="new-frontpage") }}
         </div>
         <small>{{_('Free forever.')}} <a href="{{ donate_url('header') }}">{{_('Donate')}}</a> {{_('to make it better.')}}</small>
       </div>
@@ -356,7 +356,7 @@ with great features!') }}{% endblock %}
           </span>
         </div>
         <div>
-          {{ download_thunderbird(force_direct=true, alt_copy=_('Download')) }}
+          {{ download_thunderbird(force_direct=true, alt_copy=_('Download'), section="new-frontpage") }}
         </div>
         <small>{{_('Free forever.')}} <a href="{{ donate_url('body') }}">{{_('Donate')}}</a> {{_('to make it better.')}}</small>
       </div>


### PR DESCRIPTION
Fixes #483

A temp solution because these links appear to be quite popular 😄. We can think about a prettier place to stick 'em when we move forward with the rest of the redesign.

I shifted them over to align with the download button. (They both use translate: transformX(-20px);) 

## Before
![Screen Shot 2023-10-06 at 11 01 18-fullpage](https://github.com/thundernest/thunderbird-website/assets/97147377/9b9bcbf9-3a89-47bd-b9df-314662433f98)

## After
![Screen Shot 2023-10-06 at 11 01 25-fullpage](https://github.com/thundernest/thunderbird-website/assets/97147377/f571acc8-c6b5-4b14-9897-4c1d9779b68c)
